### PR TITLE
Add DVC Pipeline Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+![Logo]()
+
+# Caldera: Pipeline Visualizer 🌋
+
+Like the center of an **active volcano**, Caldera centralizes complex flows in an intuitive graphical interface by transforming your static configuration files into clear, interactive visualizations directly within VS Code. Monitor and design all your pipelines and complex flows without leaving your favorite editor.
+
+## **Demo**
+
+![App Screenshot]()
+
+## **✨ Current Features**
+
+*   **📌 Automatic Layout**: Interactive webview with draggable and zoomable pipeline graphs.
+*   **⚡ Instant Visualization**: Opens automatically when you view a supported pipeline file.
+*   **🔄 Hot-Reload**: The graph updates in real-time as you modify your configuration files.
+*   **🔀 Multiple Orientations**: Toggle between top-to-bottom (TB) and left-to-right (LR) layouts.
+*   **✅ Node Status Indicators**: Visual indicators for success, failure, and running states.
+*   **🗺️ Mini-map**: Overview of the entire pipeline for easier navigation.
+*   **📝 Annotations & Selection**: Create visual annotations to highlight patterns and group related nodes.
+*   **📷 Image Export**: Export your pipeline visualizations as PNG images.
+*   **🔍 Auto-Detection**: Automatically detects supported pipeline files across your workspace.
+
+## **🛠️ Supported Frameworks**
+
+### CI/CD
+
+| Name | Pattern | Category |
+|------|--------|----------------------|
+| **GitHub Actions** | https://www.github.com |`.github/workflows/*.yml`, `.github/workflows/*.yaml` |
+| **GitLab CI** | https://about.gitlab.com |`.gitlab-ci.yml`, `.gitlab-ci.yaml`, `*.gitlab-ci.yml`, `*.gitlab-ci.yaml`, `.gitlab/ci/*.yml`, `.gitlab/ci/*.yaml`
+
+
+### Data Processing
+
+| Name | URL | Pattern
+|------|--------|----------------------|
+| **Apache Airflow** | https://www.airflow.apache.org | `dags/*.py`
+| **Kedro** | https://www.kedro.org | `src/**/pipeline.py`, `src/**/pipelines/**/pipeline.py`
+| **DVC** |  https://www.dvc.org | `dvc.yaml`, `dvc.yml`
+
+### AI Agent
+
+| Name | URL | Pattern |
+|------|--------|----------------------|
+| **LangChain/Langgraph** | https://www.langchain.com| `chain.py` |
+
+
+### Automation
+
+| Name | URL | Pattern
+|------|--------|----------------------|
+| **UiPath** | https://www.uipath.com |`*.xaml` |
+
+## **🎨 Theme & Colors**
+
+Caldera's visual identity is designed to be both modern and functional, ensuring optimal readability and visual appeal during extended development sessions. The color palette is carefully chosen to provide clear contrast and intuitive status recognition. 
+
+> [!INFO]
+> Currently, the extension theme is based on the Lucid Volcano theme.
+
+| Color | Hex Code | Usage |
+|-------|----------|-------|
+| **Primary Blue** | `#2563eb` | Main interface elements, active states, and primary actions |
+| **Success Green** | `#10b981` | Node success states and positive feedback indicators |
+| **Error Red** | `#ef4444` | Error states, failed nodes, and critical warnings |
+| **Warning Orange** | `#f59e0b` | Warning states and pending operations |
+| **Background Gray** | `#f8fafc` | Main background for the visualization canvas |
+| **Canvas Dark** | `#1e293b` | Dark mode background for enhanced focus |
+| **Node Border** | `#cbd5e1` | Node border outlines in light mode |
+| **Text Primary** | `#0f172a` | Main text content and labels |
+| **Text Secondary** | `#64748b` | Secondary information and muted text |
+
+These colors are used consistently throughout the extension to maintain visual coherence and provide intuitive status feedback during pipeline monitoring.
+
+## **🏗️ Architecture**
+
+*   **Modular Parser System**: Designed with a modular parser system to easily add support for new tools. All parsers implement the `IParser` interface for consistent integration.
+*   **Pipeline Categories**: Organized by type (CI/CD, Data Processing, AI Agent, RPA) with dedicated pipeline classes.
+*   **Extension Host**: Handles file watching (`vscode.workspace.onDidSaveTextDocument`) and auto-discovery.
+*   **Webview**: React application using `React Flow` for rendering and `dagre` for graph layout logic.
+*   **State Management**: Caches pipeline data to ensure the visualization is always ready, even if the webview is closed and reopened.
+*   **Shared Types**: Common types and interfaces in the `shared` directory for consistent communication between extension and webview.
+
+## **👨‍💻 Development Setup**
+
+If you want to contribute or build the project locally:
+
+1.  **Install dependencies**:
+    This is a necessity to install all the project dependencies.
+
+    ```bash
+    npm install
+    ```
+
+2.  **Compile Extension**:
+
+    This is a necessity to compile the Backend code.
+
+    ```bash
+    npm run compile
+    ```
+
+3.  **Build Webview**:
+    
+    This is a necessity to build the Webview UI (Vite - Frontend).
+    
+    ```bash
+    npm run build-webview
+    ```
+
+4.  **Run the Extension**:
+
+    Press `F5` in VS Code to launch the **Extension Development Host**.   

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,8 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  moduleNameMapper: {
+    '^vscode$': '<rootDir>/tests/vscode-mock.ts',
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2416,7 +2415,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3020,7 +3018,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3371,7 +3368,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4129,7 +4125,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5274,7 +5269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5341,7 +5335,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5351,7 +5344,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5906,7 +5898,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6050,7 +6041,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6176,7 +6166,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6270,7 +6259,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2415,6 +2416,7 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3018,6 +3020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3368,6 +3371,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4125,6 +4129,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5269,6 +5274,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5335,6 +5341,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5344,6 +5351,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5898,6 +5906,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6041,6 +6050,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6166,6 +6176,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6259,6 +6270,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,19 +1,21 @@
 import * as vscode from 'vscode';
 import { PipelineWebviewProvider } from './WebviewProvider';
+
 import { IPipeline } from './pipelines/IPipeline';
+import { ParserWithPatterns } from './pipelines/IPipeline';
 import { CICDPipeline } from './pipelines/CICDPipeline';
 import { DataProcessingPipeline } from './pipelines/DataProcessingPipeline';
 import { AIAgentPipeline } from './pipelines/AIAgentPipeline';
 import { RPAPipeline } from './pipelines/RPAPipeline';
 import { PipelineType } from '../shared/types';
-import { IParser } from './parsers/IParser';
 import { LOG_PREFIX } from './constants';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log(`${LOG_PREFIX} 🚀 Extension is activating...`);
 
     const provider = new PipelineWebviewProvider(context.extensionUri);
-    const pipelines: IPipeline[] = [
+    // Allow DataProcessingPipeline to omit 'patterns' property
+    const pipelines: (IPipeline | Omit<IPipeline, 'patterns'>)[] = [
         new CICDPipeline(),
         new DataProcessingPipeline(),
         new AIAgentPipeline(),
@@ -33,10 +35,10 @@ export function activate(context: vscode.ExtensionContext) {
                 const content = activeEditor.document.getText();
                 const pipeline = pipelines.find(p => p.type === provider.pipelineType);
                 if (pipeline) {
-                    const parser = pipeline.parsers.find(p => p.canParse(fileName, content));
+                    const parser = pipeline.parsers.find((p: any) => p.canParse(fileName, content));
                     if (parser) {
                         // Trigger discovery if the file can be parsed
-                        discoverPipelines(provider, pipeline, fileName);
+                        discoverPipelines(provider, pipeline as any, fileName);
                     }
                 }
             }
@@ -53,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
     const discover = (targetFile?: string) => {
         const pipeline = pipelines.find(p => p.type === provider.pipelineType);
         if (pipeline) {
-            discoverPipelines(provider, pipeline, targetFile).catch(error => {
+            discoverPipelines(provider, pipeline as any, targetFile).catch(error => {
                 console.error(`${LOG_PREFIX} ❌ Error during pipeline discovery:`, error);
                 provider.setLoading(false);
             });
@@ -78,10 +80,7 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     console.log(`${LOG_PREFIX} 🔍 Starting pipeline discovery...`);
-    discover();
-
     watchFiles();
-
     console.log(`${LOG_PREFIX} ✅ Extension activated successfully!`);
 }
 
@@ -89,15 +88,19 @@ async function discoverPipelines(provider: PipelineWebviewProvider, pipeline: IP
     provider.setLoading(true);
     console.log(`${LOG_PREFIX} 🔍 Discovering pipelines for category ${pipeline.type}. Target: ${targetFile || 'All'}`);
 
-    const allPipelineFiles: string[] = [];
 
-    // Find files using individual patterns to avoid nested brace issues
-    const filePromises = pipeline.patterns.map(pattern =>
-        vscode.workspace.findFiles(pattern, '**/node_modules/**')
-    );
-    const fileArrays = await Promise.all(filePromises);
-    const files = fileArrays.flat();
-    files.forEach(file => allPipelineFiles.push(file.fsPath));
+    // Collect files for each parser and keep track of which parser matches which file
+    const parserFiles: { parser: ParserWithPatterns, files: vscode.Uri[] }[] = [];
+    for (const parser of (pipeline.parsers as ParserWithPatterns[])) {
+        const foundArrays = await Promise.all(
+            parser.patterns.map(pattern => vscode.workspace.findFiles(pattern, '**/node_modules/**'))
+        );
+        const foundFiles = foundArrays.flat();
+        parserFiles.push({ parser, files: foundFiles });
+    }
+
+    // Flatten all files for the UI, but keep parser association for parsing
+    const allPipelineFiles: string[] = Array.from(new Set(parserFiles.flatMap(pf => pf.files.map(f => f.fsPath))));
 
     if (allPipelineFiles.length === 0) {
         console.log(`${LOG_PREFIX} ⚠️ No pipeline files found for category ${pipeline.type}.`);
@@ -113,24 +116,36 @@ async function discoverPipelines(provider: PipelineWebviewProvider, pipeline: IP
         return;
     }
 
-    const fileToParse = targetFile && allPipelineFiles.includes(targetFile)
-        ? vscode.Uri.file(targetFile)
-        : files[0];
+    // Pick the file to parse
+    let fileToParseUri: vscode.Uri | undefined;
+    if (targetFile && allPipelineFiles.includes(targetFile)) {
+        fileToParseUri = vscode.Uri.file(targetFile);
+    } else {
+        // Pick the first file found
+        fileToParseUri = parserFiles.find(pf => pf.files.length > 0)?.files[0];
+    }
+
+    if (!fileToParseUri) {
+        provider.setLoading(false);
+        return;
+    }
 
     try {
-        const document = await vscode.workspace.openTextDocument(fileToParse);
+        const document = await vscode.workspace.openTextDocument(fileToParseUri);
         const content = document.getText();
-        const parser = pipeline.parsers.find(p => p.canParse(fileToParse.fsPath, content));
+        // Find the parser that matches this file
+        const parser = parserFiles.find(pf => pf.files.some(f => f.fsPath === fileToParseUri!.fsPath))?.parser;
 
         if (parser) {
-            console.log(`${LOG_PREFIX} ✅ Parsing ${fileToParse.fsPath} with ${parser.name}`);
-            const data = await parser.parse(content, fileToParse.fsPath);
-            provider.updatePipeline(data, allPipelineFiles);
+            console.log(`${LOG_PREFIX} ✅ Parsing ${fileToParseUri.fsPath} with ${parser.name}`);
+            const data = await parser.parse(content, fileToParseUri.fsPath);
+            // Always set category to pipeline.type for correct webview highlight
+            provider.updatePipeline({ ...data, category: pipeline.type }, allPipelineFiles);
         } else {
-            console.log(`${LOG_PREFIX} ❓ No suitable parser for ${fileToParse.fsPath}`);
+            console.log(`${LOG_PREFIX} ❓ No suitable parser for ${fileToParseUri.fsPath}`);
         }
     } catch (error) {
-        console.error(`${LOG_PREFIX} ❌ Error parsing ${fileToParse.fsPath}:`, error);
+        console.error(`${LOG_PREFIX} ❌ Error parsing ${fileToParseUri.fsPath}:`, error);
     } finally {
         provider.setLoading(false);
     }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -35,8 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
                 if (pipeline) {
                     const parser = pipeline.parsers.find(p => p.canParse(fileName, content));
                     if (parser) {
-                        const data = parser.parse(content, fileName);
-                        // We need to re-discover to get the full list of available pipelines
+                        // Trigger discovery if the file can be parsed
                         discoverPipelines(provider, pipeline, fileName);
                     }
                 }
@@ -125,7 +124,7 @@ async function discoverPipelines(provider: PipelineWebviewProvider, pipeline: IP
 
         if (parser) {
             console.log(`${LOG_PREFIX} ✅ Parsing ${fileToParse.fsPath} with ${parser.name}`);
-            const data = parser.parse(content, fileToParse.fsPath);
+            const data = await parser.parse(content, fileToParse.fsPath);
             provider.updatePipeline(data, allPipelineFiles);
         } else {
             console.log(`${LOG_PREFIX} ❓ No suitable parser for ${fileToParse.fsPath}`);

--- a/src/extension/parsers/IParser.ts
+++ b/src/extension/parsers/IParser.ts
@@ -3,5 +3,5 @@ import { PipelineData } from '../../shared/types';
 export interface IParser {
     name: string;
     canParse(fileName: string, content: string): boolean;
-    parse(content: string, filePath: string): PipelineData;
+    parse(content: string, filePath: string): Promise<PipelineData>;
 }

--- a/src/extension/parsers/ai-agent/LangChainParser.ts
+++ b/src/extension/parsers/ai-agent/LangChainParser.ts
@@ -9,7 +9,7 @@ export class LangChainParser implements IParser {
     return content.includes("from langchain");
   }
 
-  parse(content: string, filePath: string): PipelineData {
+  async parse(content: string, filePath: string): Promise<PipelineData> {
     // Placeholder implementation
     return {
       filePath,

--- a/src/extension/parsers/cicd/GitHubActionsParser.ts
+++ b/src/extension/parsers/cicd/GitHubActionsParser.ts
@@ -9,7 +9,7 @@ export class GitHubActionsParser implements IParser {
         return fileName.endsWith('.yml') || fileName.endsWith('.yaml');
     }
 
-    parse(content: string, filePath: string): PipelineData {
+    async parse(content: string, filePath: string): Promise<PipelineData> {
         try {
             const doc = yaml.load(content) as any;
             const nodes: PipelineNode[] = [];

--- a/src/extension/parsers/cicd/GitLabCIParser.ts
+++ b/src/extension/parsers/cicd/GitLabCIParser.ts
@@ -8,7 +8,7 @@ export class GitLabCIParser implements IParser {
     return fileName.endsWith(".gitlab-ci.yml");
   }
 
-  parse(content: string, filePath: string): PipelineData {
+  async parse(content: string, filePath: string): Promise<PipelineData> {
     // Placeholder implementation
     return {
       filePath,

--- a/src/extension/parsers/data-processing/AirflowParser.ts
+++ b/src/extension/parsers/data-processing/AirflowParser.ts
@@ -9,7 +9,7 @@ export class AirflowParser implements IParser {
     return content.includes("from airflow import DAG");
   }
 
-  parse(content: string, filePath: string): PipelineData {
+  async parse(content: string, filePath: string): Promise<PipelineData> {
     // Placeholder implementation
     return {
       filePath,

--- a/src/extension/parsers/data-processing/DVCParser.ts
+++ b/src/extension/parsers/data-processing/DVCParser.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -7,21 +7,29 @@ import { IParser } from '../IParser';
 import { PipelineData, PipelineNode, PipelineEdge } from '../../../shared/types';
 
 const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
+
+export interface CommandInfo {
+    command: string;
+    args: string[];
+}
 
 export class DVCParser implements IParser {
     name = 'DVC';
+    private dvcCmdCache = new Map<string, CommandInfo>();
 
     canParse(fileName: string, content: string): boolean {
-        return fileName.endsWith('dvc.yaml');
+        const lowerName = fileName.toLowerCase();
+        return lowerName.endsWith('dvc.yaml') || lowerName.endsWith('dvc.yml');
     }
 
     async parse(content: string, filePath: string): Promise<PipelineData> {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
         const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : path.dirname(filePath);
 
-        const dvcCmd = await this.getDVCCmd(cwd);
+        const dvcCmdInfo = await this.getDVCCmd(cwd);
 
-        if (!dvcCmd) {
+        if (!dvcCmdInfo) {
             vscode.window.showWarningMessage(
                 "If you are trying to view a DVC pipeline, you need to have the DVC CLI available in your environment."
             );
@@ -35,7 +43,7 @@ export class DVCParser implements IParser {
 
         try {
             // Using --mermaid as it's easier to parse than ASCII
-            const { stdout } = await execPromise(`${dvcCmd} dag --mermaid`, { cwd });
+            const { stdout } = await this.execDvcDagMermaid(dvcCmdInfo, cwd);
             return this.parseMermaid(stdout, filePath);
         } catch (error) {
             console.error('Failed to parse DVC pipeline using CLI:', error);
@@ -48,14 +56,20 @@ export class DVCParser implements IParser {
         }
     }
 
+    private async execDvcDagMermaid(dvcCmdInfo: CommandInfo, cwd: string) {
+        const fullArgs = [...dvcCmdInfo.args, 'dag', '--mermaid'];
+        return execFilePromise(dvcCmdInfo.command, fullArgs, { cwd });
+    }
+
     private parseMermaid(mermaid: string, filePath: string): PipelineData {
         const nodes: PipelineNode[] = [];
         const edges: PipelineEdge[] = [];
 
         // Example node: 	node1["node1"]
-        const nodeRegex = /^\s*([\w-]+)\["(.*)"\]/gm;
+        // Loosened to allow more characters in ID and label
+        const nodeRegex = /^\s*([^\s\[]+)\["(.*)"\]/gm;
         // Example edge: 	node1 --> node2
-        const edgeRegex = /^\s*([\w-]+)\s*-->\s*([\w-]+)/gm;
+        const edgeRegex = /^\s*([^\s-]+)\s*-->\s*([^\s]+)/gm;
 
         let match;
         while ((match = nodeRegex.exec(mermaid)) !== null) {
@@ -82,7 +96,11 @@ export class DVCParser implements IParser {
         };
     }
 
-    private async getDVCCmd(cwd: string): Promise<string | null> {
+    private async getDVCCmd(cwd: string): Promise<CommandInfo | null> {
+        if (this.dvcCmdCache.has(cwd)) {
+            return this.dvcCmdCache.get(cwd)!;
+        }
+
         const isWindows = process.platform === 'win32';
 
         // 1. Check local virtual environment
@@ -92,33 +110,44 @@ export class DVCParser implements IParser {
             path.join(cwd, 'env', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
         ];
 
+        let result: CommandInfo | null = null;
+
         for (const venvDvc of venvPaths) {
             if (fs.existsSync(venvDvc)) {
-                return venvDvc;
+                result = { command: venvDvc, args: [] };
+                break;
             }
         }
 
-        // 2. Check uv
-        try {
-            await execPromise('uv --version');
-            // If uv exists, check if dvc is available through it
-            await execPromise('uv run dvc --version', { cwd });
-            return 'uv run dvc';
-        } catch {}
+        if (!result) {
+            // 2. Check uv
+            try {
+                await execPromise('uv --version');
+                await execPromise('uv run dvc --version', { cwd });
+                result = { command: 'uv', args: ['run', 'dvc'] };
+            } catch {}
+        }
 
-        // 3. Check pipx
-        try {
-            await execPromise('pipx --version');
-            await execPromise('pipx run dvc --version');
-            return 'pipx run dvc';
-        } catch {}
+        if (!result) {
+            // 3. Check pipx
+            try {
+                await execPromise('pipx --version');
+                await execPromise('pipx run dvc --version');
+                result = { command: 'pipx', args: ['run', 'dvc'] };
+            } catch {}
+        }
 
-        // 4. Check global dvc
-        try {
-            await execPromise('dvc --version');
-            return 'dvc';
-        } catch {}
+        if (!result) {
+            // 4. Check global dvc
+            try {
+                await execPromise('dvc --version');
+                result = { command: 'dvc', args: [] };
+            } catch {}
+        }
 
-        return null;
+        if (result) {
+            this.dvcCmdCache.set(cwd, result);
+        }
+        return result;
     }
 }

--- a/src/extension/parsers/data-processing/DVCParser.ts
+++ b/src/extension/parsers/data-processing/DVCParser.ts
@@ -104,11 +104,13 @@ export class DVCParser implements IParser {
         const isWindows = process.platform === 'win32';
 
         // 1. Check local virtual environment
-        const venvPaths = [
-            path.join(cwd, '.venv', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
-            path.join(cwd, 'venv', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
-            path.join(cwd, 'env', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
-        ];
+        const venvDirs = ['.venv', 'venv', 'env'];
+        const venvPaths: string[] = [];
+        for (const dir of venvDirs) {
+            venvPaths.push(
+            path.join(cwd, dir, isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc')
+            );
+        }
 
         let result: CommandInfo | null = null;
 

--- a/src/extension/parsers/data-processing/DVCParser.ts
+++ b/src/extension/parsers/data-processing/DVCParser.ts
@@ -18,6 +18,8 @@ export interface CommandInfo {
 export class DVCParser implements IParser {
     name = 'DVC';
     private dvcCmdCache = new Map<string, { commandInfo: CommandInfo, isLocal: boolean }>();
+    private paramsCache = new Map<string, any>();
+    private globalWarningShown = new Set<string>();
 
     canParse(fileName: string, content: string): boolean {
         const lowerName = fileName.toLowerCase();
@@ -28,12 +30,15 @@ export class DVCParser implements IParser {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
         const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : path.dirname(filePath);
 
-        const { commandInfo: dvcCmdInfo, isLocal } = await this.getDVCCmd(cwd);
+        const dvcResolution = await this.getDVCCmd(cwd);
 
-        if (!dvcCmdInfo) {
-            vscode.window.showWarningMessage(
-                "If you are trying to view a DVC pipeline, you need to have the DVC CLI available in your environment."
-            );
+        if (!dvcResolution) {
+            if (!this.globalWarningShown.has(cwd)) {
+                vscode.window.showWarningMessage(
+                    "If you are trying to view a DVC pipeline, you need to have the DVC CLI available in your environment."
+                );
+                this.globalWarningShown.add(cwd);
+            }
             return {
                 filePath,
                 framework: this.name,
@@ -42,10 +47,13 @@ export class DVCParser implements IParser {
             };
         }
 
-        if (!isLocal) {
+        const { commandInfo: dvcCmdInfo, isLocal } = dvcResolution;
+
+        if (!isLocal && !this.globalWarningShown.has(cwd)) {
             vscode.window.showWarningMessage(
                 "DVC needs to be installed inside the environment and not globally for the extension to understand DVC pipelines."
             );
+            this.globalWarningShown.add(cwd);
         }
 
         try {
@@ -69,6 +77,10 @@ export class DVCParser implements IParser {
     }
 
     private async getParamsValues(dvcCmdInfo: CommandInfo, cwd: string): Promise<any> {
+        if (this.paramsCache.has(cwd)) {
+            return this.paramsCache.get(cwd);
+        }
+
         let command = 'python3';
         let args = ['-c', "import dvc.api; import json; print(json.dumps(dvc.api.params_show()))"];
 
@@ -85,7 +97,9 @@ export class DVCParser implements IParser {
 
         try {
             const { stdout } = await execFilePromise(command, args, { cwd });
-            return JSON.parse(stdout);
+            const params = JSON.parse(stdout);
+            this.paramsCache.set(cwd, params);
+            return params;
         } catch (error) {
             console.error('Failed to get DVC params:', error);
             return {};
@@ -131,26 +145,22 @@ export class DVCParser implements IParser {
 
     private listFolderContents(folderPath: string, cwd: string): string[] {
         const fullPath = path.isAbsolute(folderPath) ? folderPath : path.join(cwd, folderPath);
-        if (fs.existsSync(fullPath) && fs.statSync(fullPath).isDirectory()) {
-            try {
+        try {
+            if (fs.existsSync(fullPath) && fs.statSync(fullPath).isDirectory()) {
                 return fs.readdirSync(fullPath).slice(0, 5); // Limit to 5 items for display
-            } catch (error) {
-                console.error(`Failed to list folder ${folderPath}:`, error);
             }
+        } catch (error) {
+            console.error(`Failed to list folder ${folderPath}:`, error);
         }
         return [];
     }
 
-    private async parseEnhanced(mermaid: string, filePath: string, dvcCmdInfo: CommandInfo, cwd: string): Promise<PipelineData> {
-        const nodes: PipelineNode[] = [];
-        const edges: PipelineEdge[] = [];
-        const lockData = this.getLockFileData(cwd);
-        const paramsData = await this.getParamsValues(dvcCmdInfo, cwd);
+    // Pure helpers for parsing
 
-        // Map to keep track of outputs and who produced them
-        const outputToProducer = new Map<string, string>();
+    public buildStageMaps(lockData: any): { stageToOutputs: Map<string, string[]>, stageToDeps: Map<string, string[]>, outputToProducer: Map<string, string> } {
         const stageToOutputs = new Map<string, string[]>();
         const stageToDeps = new Map<string, string[]>();
+        const outputToProducer = new Map<string, string>();
 
         if (lockData && lockData.stages) {
             for (const [stageName, stageData] of Object.entries<any>(lockData.stages)) {
@@ -165,17 +175,24 @@ export class DVCParser implements IParser {
                 }
             }
         }
+        return { stageToOutputs, stageToDeps, outputToProducer };
+    }
 
+    public buildStageAndArtifactNodes(
+        mermaid: string,
+        stageToOutputs: Map<string, string[]>,
+        stageToDeps: Map<string, string[]>,
+        paramsData: any,
+        cwd: string
+    ): { nodes: PipelineNode[], artifactByPath: Map<string, PipelineNode> } {
+        const nodes: PipelineNode[] = [];
+        const artifactByPath = new Map<string, PipelineNode>();
         const nodeRegex = /^\s*([^\s\[]+)\["(.*)"\]/gm;
-        const edgeRegex = /^\s*([^\s-]+)\s*-->\s*([^\s]+)/gm;
 
         let match;
-        const processedStages = new Set<string>();
-
         while ((match = nodeRegex.exec(mermaid)) !== null) {
             const id = match[1];
             const label = match[2];
-            processedStages.add(label);
 
             const isArtifact = label.toLowerCase().endsWith('.dvc');
 
@@ -196,7 +213,7 @@ export class DVCParser implements IParser {
                     }
                 }
 
-                nodes.push({
+                const node: PipelineNode = {
                     id,
                     label,
                     type: 'artifact',
@@ -204,7 +221,8 @@ export class DVCParser implements IParser {
                         framework: this.name,
                         dataType
                     }
-                });
+                };
+                nodes.push(node);
             } else {
                 const stageDeps = stageToDeps.get(label) || [];
                 const codeDeps = stageDeps
@@ -248,7 +266,7 @@ export class DVCParser implements IParser {
                     }
                 }
 
-                nodes.push({
+                const node: PipelineNode = {
                     id: artifactId,
                     label: out,
                     type: 'artifact',
@@ -256,55 +274,113 @@ export class DVCParser implements IParser {
                         dataType,
                         contents: isFolder ? this.listFolderContents(out, cwd) : undefined
                     }
-                });
-
-                edges.push({
-                    id: `e-${id}-${artifactId}`,
-                    source: id,
-                    target: artifactId
-                });
+                };
+                nodes.push(node);
+                artifactByPath.set(out, node);
             });
         }
+        return { nodes, artifactByPath };
+    }
 
-        while ((match = edgeRegex.exec(mermaid)) !== null) {
-            const sourceId = match[1];
-            const targetId = match[2];
-
-            // Find labels
-            const sourceNode = nodes.find(n => n.id === sourceId);
-            const targetNode = nodes.find(n => n.id === targetId);
-
-            if (sourceNode && targetNode) {
-                const sourceLabel = sourceNode.label;
-                const targetLabel = targetNode.label;
-
-                // Check if there's an artifact that connects them
-                const outputs = stageToOutputs.get(sourceLabel) || [];
-                const inputs = stageToDeps.get(targetLabel) || [];
-                const common = outputs.filter(o => inputs.includes(o));
-
-                if (common.length > 0) {
-                    // Link artifact to target stage
-                    common.forEach(out => {
-                        const artifactNode = nodes.find(n => n.label === out && n.type === 'artifact' && edges.some(e => e.source === sourceId && e.target === n.id));
-                        if (artifactNode) {
-                            edges.push({
-                                id: `e-${artifactNode.id}-${targetId}`,
-                                source: artifactNode.id,
-                                target: targetId
-                            });
-                        }
-                    });
-                } else {
-                    // Fallback to direct edge if no common artifact found (might be code dep or something else)
-                    edges.push({
-                        id: `e-${sourceId}-${targetId}`,
-                        source: sourceId,
-                        target: targetId
-                    });
+    public buildEdges(
+        mermaid: string,
+        nodes: PipelineNode[],
+        stageToOutputs: Map<string, string[]>,
+        stageToDeps: Map<string, string[]>,
+        artifactByPath: Map<string, PipelineNode>
+    ): PipelineEdge[] {
+        const edges: PipelineEdge[] = [];
+        const nodeById = new Map(nodes.map(n => [n.id, n]));
+        const edgeRegex = /^\s*([^\s-]+)\s*-->\s*([^\s]+)/gm;
+        
+        // Also add edges from stages to their output artifacts
+        // This was previously done inside the node loop, but now we have artifactByPath
+        // We can reconstruct these edges easily if we know which stage produced which artifact
+        // Wait, the original code added these edges:
+        // edges.push({ id: `e-${id}-${artifactId}`, source: id, target: artifactId });
+        // Since we are iterating nodes again in buildEdges? No, buildEdges iterates MERMAID edges.
+        // We missed the "stage -> output artifact" edges. Let's add them.
+        
+        // Retain the logic for "stage -> output artifact"
+        // We can do this by iterating nodes and checking if they are stage nodes that have outputs
+        // But better yet, buildStageAndArtifactNodes could return these initial edges too?
+        // Or we just add them here.
+        
+        // Let's iterate the nodes to add "Stage -> Artifact" edges first
+        for (const node of nodes) {
+            if (node.type === 'default') {
+                const outputs = stageToOutputs.get(node.label) || [];
+                for (const out of outputs) {
+                    const artifactNode = artifactByPath.get(out);
+                    if (artifactNode) {
+                        edges.push({
+                            id: `e-${node.id}-${artifactNode.id}`,
+                            source: node.id,
+                            target: artifactNode.id
+                        });
+                    }
                 }
             }
         }
+
+        let match;
+        while ((match = edgeRegex.exec(mermaid)) !== null) {
+            const sourceId = match[1];
+            const targetId = match[2];
+            const sourceNode = nodeById.get(sourceId);
+            const targetNode = nodeById.get(targetId);
+            
+            if (!sourceNode || !targetNode) continue;
+
+            const outputs = stageToOutputs.get(sourceNode.label) || [];
+            const inputs = stageToDeps.get(targetNode.label) || [];
+            const common = outputs.filter(o => inputs.includes(o));
+
+            if (common.length > 0) {
+                for (const out of common) {
+                    const artifactNode = artifactByPath.get(out);
+                    if (!artifactNode) continue;
+
+                    // Source -> Artifact is already added above (if source is the producer)
+                    // But wait, DVC mermaid edges are Stage -> Stage.
+                    // So we want Stage -> Artifact -> Stage.
+                    // The Stage -> Artifact edge is added in the loop above (producer -> artifact)
+                    // Here we add Artifact -> TargetStage
+                    
+                    edges.push({
+                        id: `e-${artifactNode.id}-${targetId}`,
+                        source: artifactNode.id,
+                        target: targetId
+                    });
+                }
+            } else {
+                 // Fallback to direct edge
+                edges.push({
+                    id: `e-${sourceId}-${targetId}`,
+                    source: sourceId,
+                    target: targetId
+                });
+            }
+        }
+
+        return edges;
+    }
+
+    private async parseEnhanced(mermaid: string, filePath: string, dvcCmdInfo: CommandInfo, cwd: string): Promise<PipelineData> {
+        const lockData = this.getLockFileData(cwd);
+        const paramsData = await this.getParamsValues(dvcCmdInfo, cwd);
+
+        const { stageToOutputs, stageToDeps } = this.buildStageMaps(lockData);
+
+        const { nodes, artifactByPath } = this.buildStageAndArtifactNodes(
+            mermaid,
+            stageToOutputs,
+            stageToDeps,
+            paramsData,
+            cwd
+        );
+
+        const edges = this.buildEdges(mermaid, nodes, stageToOutputs, stageToDeps, artifactByPath);
 
         return {
             filePath,
@@ -314,7 +390,7 @@ export class DVCParser implements IParser {
         };
     }
 
-    private async getDVCCmd(cwd: string): Promise<{ commandInfo: CommandInfo | null, isLocal: boolean }> {
+    private async getDVCCmd(cwd: string): Promise<{ commandInfo: CommandInfo; isLocal: boolean } | null> {
         if (this.dvcCmdCache.has(cwd)) {
             return this.dvcCmdCache.get(cwd)!;
         }
@@ -367,11 +443,12 @@ export class DVCParser implements IParser {
             } catch { }
         }
 
-        const result = { commandInfo, isLocal };
         if (commandInfo) {
-            // Only cache if commandInfo is not null, and type matches cache type
-            this.dvcCmdCache.set(cwd, { commandInfo, isLocal });
+            const result = { commandInfo, isLocal };
+            this.dvcCmdCache.set(cwd, result);
+            return result;
         }
-        return result;
+        
+        return null;
     }
 }

--- a/src/extension/parsers/data-processing/DVCParser.ts
+++ b/src/extension/parsers/data-processing/DVCParser.ts
@@ -1,0 +1,124 @@
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as path from 'path';
+import * as fs from 'fs';
+import { IParser } from '../IParser';
+import { PipelineData, PipelineNode, PipelineEdge } from '../../../shared/types';
+
+const execPromise = promisify(exec);
+
+export class DVCParser implements IParser {
+    name = 'DVC';
+
+    canParse(fileName: string, content: string): boolean {
+        return fileName.endsWith('dvc.yaml');
+    }
+
+    async parse(content: string, filePath: string): Promise<PipelineData> {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+        const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : path.dirname(filePath);
+
+        const dvcCmd = await this.getDVCCmd(cwd);
+
+        if (!dvcCmd) {
+            vscode.window.showWarningMessage(
+                "If you are trying to view a DVC pipeline, you need to have the DVC CLI available in your environment."
+            );
+            return {
+                filePath,
+                framework: this.name,
+                nodes: [],
+                edges: []
+            };
+        }
+
+        try {
+            // Using --mermaid as it's easier to parse than ASCII
+            const { stdout } = await execPromise(`${dvcCmd} dag --mermaid`, { cwd });
+            return this.parseMermaid(stdout, filePath);
+        } catch (error) {
+            console.error('Failed to parse DVC pipeline using CLI:', error);
+            return {
+                filePath,
+                framework: this.name,
+                nodes: [],
+                edges: []
+            };
+        }
+    }
+
+    private parseMermaid(mermaid: string, filePath: string): PipelineData {
+        const nodes: PipelineNode[] = [];
+        const edges: PipelineEdge[] = [];
+
+        // Example node: 	node1["node1"]
+        const nodeRegex = /^\s*([\w-]+)\["(.*)"\]/gm;
+        // Example edge: 	node1 --> node2
+        const edgeRegex = /^\s*([\w-]+)\s*-->\s*([\w-]+)/gm;
+
+        let match;
+        while ((match = nodeRegex.exec(mermaid)) !== null) {
+            nodes.push({
+                id: match[1],
+                label: match[2],
+                type: 'default'
+            });
+        }
+
+        while ((match = edgeRegex.exec(mermaid)) !== null) {
+            edges.push({
+                id: `e-${match[1]}-${match[2]}`,
+                source: match[1],
+                target: match[2]
+            });
+        }
+
+        return {
+            filePath,
+            framework: this.name,
+            nodes,
+            edges
+        };
+    }
+
+    private async getDVCCmd(cwd: string): Promise<string | null> {
+        const isWindows = process.platform === 'win32';
+
+        // 1. Check local virtual environment
+        const venvPaths = [
+            path.join(cwd, '.venv', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
+            path.join(cwd, 'venv', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
+            path.join(cwd, 'env', isWindows ? 'Scripts' : 'bin', isWindows ? 'dvc.exe' : 'dvc'),
+        ];
+
+        for (const venvDvc of venvPaths) {
+            if (fs.existsSync(venvDvc)) {
+                return venvDvc;
+            }
+        }
+
+        // 2. Check uv
+        try {
+            await execPromise('uv --version');
+            // If uv exists, check if dvc is available through it
+            await execPromise('uv run dvc --version', { cwd });
+            return 'uv run dvc';
+        } catch {}
+
+        // 3. Check pipx
+        try {
+            await execPromise('pipx --version');
+            await execPromise('pipx run dvc --version');
+            return 'pipx run dvc';
+        } catch {}
+
+        // 4. Check global dvc
+        try {
+            await execPromise('dvc --version');
+            return 'dvc';
+        } catch {}
+
+        return null;
+    }
+}

--- a/src/extension/parsers/data-processing/DVCParser.ts
+++ b/src/extension/parsers/data-processing/DVCParser.ts
@@ -3,6 +3,7 @@ import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as yaml from 'js-yaml';
 import { IParser } from '../IParser';
 import { PipelineData, PipelineNode, PipelineEdge } from '../../../shared/types';
 
@@ -16,7 +17,7 @@ export interface CommandInfo {
 
 export class DVCParser implements IParser {
     name = 'DVC';
-    private dvcCmdCache = new Map<string, CommandInfo>();
+    private dvcCmdCache = new Map<string, { commandInfo: CommandInfo, isLocal: boolean }>();
 
     canParse(fileName: string, content: string): boolean {
         const lowerName = fileName.toLowerCase();
@@ -27,7 +28,7 @@ export class DVCParser implements IParser {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
         const cwd = workspaceFolder ? workspaceFolder.uri.fsPath : path.dirname(filePath);
 
-        const dvcCmdInfo = await this.getDVCCmd(cwd);
+        const { commandInfo: dvcCmdInfo, isLocal } = await this.getDVCCmd(cwd);
 
         if (!dvcCmdInfo) {
             vscode.window.showWarningMessage(
@@ -41,10 +42,16 @@ export class DVCParser implements IParser {
             };
         }
 
+        if (!isLocal) {
+            vscode.window.showWarningMessage(
+                "DVC needs to be installed inside the environment and not globally for the extension to understand DVC pipelines."
+            );
+        }
+
         try {
             // Using --mermaid as it's easier to parse than ASCII
             const { stdout } = await this.execDvcDagMermaid(dvcCmdInfo, cwd);
-            return this.parseMermaid(stdout, filePath);
+            return this.parseEnhanced(stdout, filePath, dvcCmdInfo, cwd);
         } catch (error) {
             console.error('Failed to parse DVC pipeline using CLI:', error);
             return {
@@ -61,54 +68,198 @@ export class DVCParser implements IParser {
         return execFilePromise(dvcCmdInfo.command, fullArgs, { cwd });
     }
 
-    private parseMermaid(mermaid: string, filePath: string): PipelineData {
+    private async getParamsValues(dvcCmdInfo: CommandInfo, cwd: string): Promise<any> {
+        let command = 'python3';
+        let args = ['-c', "import dvc.api; import json; print(json.dumps(dvc.api.params_show()))"];
+
+        if (dvcCmdInfo.command.endsWith('dvc') || dvcCmdInfo.command.endsWith('dvc.exe')) {
+            const binDir = path.dirname(dvcCmdInfo.command);
+            const venvPython = path.join(binDir, process.platform === 'win32' ? 'python.exe' : 'python');
+            if (fs.existsSync(venvPython)) {
+                command = venvPython;
+            }
+        } else if (dvcCmdInfo.command === 'uv') {
+            command = 'uv';
+            args = ['run', 'python', ...args];
+        }
+
+        try {
+            const { stdout } = await execFilePromise(command, args, { cwd });
+            return JSON.parse(stdout);
+        } catch (error) {
+            console.error('Failed to get DVC params:', error);
+            return {};
+        }
+    }
+
+    private getLockFileData(cwd: string): any {
+        const lockFilePath = path.join(cwd, 'dvc.lock');
+        if (fs.existsSync(lockFilePath)) {
+            try {
+                const content = fs.readFileSync(lockFilePath, 'utf8');
+                return yaml.load(content);
+            } catch (error) {
+                console.error('Failed to parse dvc.lock:', error);
+            }
+        }
+        return null;
+    }
+
+    private categorizeDep(filePath: string): 'code' | 'data' | 'other' {
+        const ext = path.extname(filePath).toLowerCase();
+        if (['.py', '.sh', '.r', '.jl', '.pl', '.rb'].includes(ext)) {
+            return 'code';
+        }
+        if (['.csv', '.tsv', '.parquet', '.json', '.txt', '.xml', '.yaml', '.yml'].includes(ext)) {
+            return 'data';
+        }
+        return 'other';
+    }
+
+    private readFileSnippet(filePath: string, cwd: string): string {
+        const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+        if (fs.existsSync(fullPath)) {
+            try {
+                const content = fs.readFileSync(fullPath, 'utf8');
+                return content.split('\n').slice(0, 10).join('\n'); // First 10 lines
+            } catch (error) {
+                console.error(`Failed to read file ${filePath}:`, error);
+            }
+        }
+        return '';
+    }
+
+    private listFolderContents(folderPath: string, cwd: string): string[] {
+        const fullPath = path.isAbsolute(folderPath) ? folderPath : path.join(cwd, folderPath);
+        if (fs.existsSync(fullPath) && fs.statSync(fullPath).isDirectory()) {
+            try {
+                return fs.readdirSync(fullPath).slice(0, 5); // Limit to 5 items for display
+            } catch (error) {
+                console.error(`Failed to list folder ${folderPath}:`, error);
+            }
+        }
+        return [];
+    }
+
+    private async parseEnhanced(mermaid: string, filePath: string, dvcCmdInfo: CommandInfo, cwd: string): Promise<PipelineData> {
         const nodes: PipelineNode[] = [];
         const edges: PipelineEdge[] = [];
+        const lockData = this.getLockFileData(cwd);
+        const paramsData = await this.getParamsValues(dvcCmdInfo, cwd);
 
-        // Example node: 	node1["node1"]
-        // Loosened to allow more characters in ID and label
+        // Map to keep track of outputs and who produced them
+        const outputToProducer = new Map<string, string>();
+        const stageToOutputs = new Map<string, string[]>();
+        const stageToDeps = new Map<string, string[]>();
+
+        if (lockData && lockData.stages) {
+            for (const [stageName, stageData] of Object.entries<any>(lockData.stages)) {
+                if (stageData.outs) {
+                    const outs = stageData.outs.map((o: any) => o.path);
+                    stageToOutputs.set(stageName, outs);
+                    outs.forEach((out: string) => outputToProducer.set(out, stageName));
+                }
+                if (stageData.deps) {
+                    const deps = stageData.deps.map((d: any) => d.path);
+                    stageToDeps.set(stageName, deps);
+                }
+            }
+        }
+
         const nodeRegex = /^\s*([^\s\[]+)\["(.*)"\]/gm;
-        // Example edge: 	node1 --> node2
         const edgeRegex = /^\s*([^\s-]+)\s*-->\s*([^\s]+)/gm;
 
         let match;
+        const processedStages = new Set<string>();
+
         while ((match = nodeRegex.exec(mermaid)) !== null) {
             const id = match[1];
             const label = match[2];
-            const isArtifact = label.toLowerCase().endsWith('.dvc');
+            processedStages.add(label);
 
-            let dataType = 'other';
-            if (isArtifact) {
-                const baseName = label.slice(0, -4); // remove .dvc
-                const extMatch = baseName.match(/\.([^.]+)$/);
-                if (extMatch) {
-                    const ext = extMatch[1].toLowerCase();
-                    if (['png', 'tiff', 'jpg', 'jpeg'].includes(ext)) {
-                        dataType = 'image';
-                    } else if (['csv', 'tsv', 'parquet', 'feather', 'xlsx', 'xml'].includes(ext)) {
-                        dataType = 'table';
-                    } else if (['mp4', 'mov', 'mkv'].includes(ext)) {
-                        dataType = 'video';
-                    } else if (['mp3', 'ogg', 'aac', 'opus', 'wav'].includes(ext)) {
-                        dataType = 'audio';
-                    }
-                }
-            }
+            const stageDeps = stageToDeps.get(label) || [];
+            const codeDeps = stageDeps
+                .filter(d => this.categorizeDep(d) === 'code')
+                .map(d => ({ path: d, snippet: this.readFileSnippet(d, cwd) }));
+
+            const stageParams = paramsData[label] || paramsData; // Some params might be global or stage-specific
 
             nodes.push({
                 id,
                 label,
-                type: isArtifact ? 'artifact' : 'default',
-                data: isArtifact ? { dataType } : undefined
+                type: 'default',
+                data: {
+                    framework: this.name,
+                    codeDeps,
+                    params: stageParams
+                }
+            });
+
+            // Add artifact nodes for outputs
+            const stageOuts = stageToOutputs.get(label) || [];
+            stageOuts.forEach((out, index) => {
+                const artifactId = `art-${id}-${index}`;
+                const isFolder = !path.extname(out);
+
+                nodes.push({
+                    id: artifactId,
+                    label: out,
+                    type: 'artifact',
+                    data: {
+                        dataType: isFolder ? 'folder' : 'file',
+                        contents: isFolder ? this.listFolderContents(out, cwd) : undefined
+                    }
+                });
+
+                edges.push({
+                    id: `e-${id}-${artifactId}`,
+                    source: id,
+                    target: artifactId
+                });
+
+                // Link artifact to consuming stages
+                // We'll handle this in the edge loop or by checking all stages
             });
         }
 
         while ((match = edgeRegex.exec(mermaid)) !== null) {
-            edges.push({
-                id: `e-${match[1]}-${match[2]}`,
-                source: match[1],
-                target: match[2]
-            });
+            const sourceId = match[1];
+            const targetId = match[2];
+
+            // Find labels
+            const sourceNode = nodes.find(n => n.id === sourceId);
+            const targetNode = nodes.find(n => n.id === targetId);
+
+            if (sourceNode && targetNode) {
+                const sourceLabel = sourceNode.label;
+                const targetLabel = targetNode.label;
+
+                // Check if there's an artifact that connects them
+                const outputs = stageToOutputs.get(sourceLabel) || [];
+                const inputs = stageToDeps.get(targetLabel) || [];
+                const common = outputs.filter(o => inputs.includes(o));
+
+                if (common.length > 0) {
+                    // Link artifact to target stage
+                    common.forEach(out => {
+                        const artifactNode = nodes.find(n => n.label === out && n.type === 'artifact' && edges.some(e => e.source === sourceId && e.target === n.id));
+                        if (artifactNode) {
+                            edges.push({
+                                id: `e-${artifactNode.id}-${targetId}`,
+                                source: artifactNode.id,
+                                target: targetId
+                            });
+                        }
+                    });
+                } else {
+                    // Fallback to direct edge if no common artifact found (might be code dep or something else)
+                    edges.push({
+                        id: `e-${sourceId}-${targetId}`,
+                        source: sourceId,
+                        target: targetId
+                    });
+                }
+            }
         }
 
         return {
@@ -119,7 +270,7 @@ export class DVCParser implements IParser {
         };
     }
 
-    private async getDVCCmd(cwd: string): Promise<CommandInfo | null> {
+    private async getDVCCmd(cwd: string): Promise<{ commandInfo: CommandInfo | null, isLocal: boolean }> {
         if (this.dvcCmdCache.has(cwd)) {
             return this.dvcCmdCache.get(cwd)!;
         }
@@ -135,42 +286,45 @@ export class DVCParser implements IParser {
             );
         }
 
-        let result: CommandInfo | null = null;
+        let commandInfo: CommandInfo | null = null;
+        let isLocal = false;
 
         for (const venvDvc of venvPaths) {
             if (fs.existsSync(venvDvc)) {
-                result = { command: venvDvc, args: [] };
+                commandInfo = { command: venvDvc, args: [] };
+                isLocal = true;
                 break;
             }
         }
 
-        if (!result) {
+        if (!commandInfo) {
             // 2. Check uv
             try {
                 await execPromise('uv --version');
                 await execPromise('uv run dvc --version', { cwd });
-                result = { command: 'uv', args: ['run', 'dvc'] };
+                commandInfo = { command: 'uv', args: ['run', 'dvc'] };
             } catch { }
         }
 
-        if (!result) {
+        if (!commandInfo) {
             // 3. Check pipx
             try {
                 await execPromise('pipx --version');
                 await execPromise('pipx run dvc --version');
-                result = { command: 'pipx', args: ['run', 'dvc'] };
+                commandInfo = { command: 'pipx', args: ['run', 'dvc'] };
             } catch { }
         }
 
-        if (!result) {
+        if (!commandInfo) {
             // 4. Check global dvc
             try {
                 await execPromise('dvc --version');
-                result = { command: 'dvc', args: [] };
+                commandInfo = { command: 'dvc', args: [] };
             } catch { }
         }
 
-        if (result) {
+        const result = { commandInfo, isLocal };
+        if (commandInfo) {
             this.dvcCmdCache.set(cwd, result);
         }
         return result;

--- a/src/extension/parsers/data-processing/KedroParser.ts
+++ b/src/extension/parsers/data-processing/KedroParser.ts
@@ -9,7 +9,7 @@ export class KedroParser implements IParser {
     return content.includes("create_pipeline");
   }
 
-  parse(content: string, filePath: string): PipelineData {
+  async parse(content: string, filePath: string): Promise<PipelineData> {
     // Placeholder implementation
     return {
       filePath,

--- a/src/extension/parsers/rpa/UiPathParser.ts
+++ b/src/extension/parsers/rpa/UiPathParser.ts
@@ -9,7 +9,7 @@ export class UiPathParser implements IParser {
     return fileName.endsWith(".xaml");
   }
 
-  parse(content: string, filePath: string): PipelineData {
+  async parse(content: string, filePath: string): Promise<PipelineData> {
     // Placeholder implementation
     return {
       filePath,

--- a/src/extension/pipelines/AIAgentPipeline.ts
+++ b/src/extension/pipelines/AIAgentPipeline.ts
@@ -1,12 +1,10 @@
-import { IPipeline } from "./IPipeline";
-import { IParser } from "../parsers/IParser";
+import { IPipeline, ParserWithPatterns } from "./IPipeline";
 import { PipelineType } from "../../shared/types";
 import { LangChainParser } from "../parsers/ai-agent/LangChainParser";
 
 export class AIAgentPipeline implements IPipeline {
   type: PipelineType = PipelineType.AIAgent;
-  parsers: IParser[] = [new LangChainParser()];
-  patterns: string[] = [
-    '**/*.py', // For LangChain, could be more specific
+  parsers: ParserWithPatterns[] = [
+    Object.assign(new LangChainParser(), { patterns: ['**/chain.py'] }),
   ];
 }

--- a/src/extension/pipelines/CICDPipeline.ts
+++ b/src/extension/pipelines/CICDPipeline.ts
@@ -1,15 +1,12 @@
-import { IPipeline } from "./IPipeline";
-import { IParser } from "../parsers/IParser";
+import { IPipeline, ParserWithPatterns } from "./IPipeline";
 import { PipelineType } from "../../shared/types";
 import { GitHubActionsParser } from "../parsers/cicd/GitHubActionsParser";
 import { GitLabCIParser } from "../parsers/cicd/GitLabCIParser";
 
 export class CICDPipeline implements IPipeline {
   type: PipelineType = PipelineType.CICD;
-  parsers: IParser[] = [new GitHubActionsParser(), new GitLabCIParser()];
-  patterns: string[] = [
-    '**/.github/workflows/*.yml',
-    '**/.github/workflows/*.yaml',
-    '**/.gitlab-ci.yml',
+  parsers: ParserWithPatterns[] = [
+    Object.assign(new GitHubActionsParser(), { patterns: ['**/.github/workflows/*.yml', '**/.github/workflows/*.yaml'] }),
+    Object.assign(new GitLabCIParser(), { patterns: ['**/.gitlab-ci.yml', '**/.gitlab-ci.yaml', '**/*.gitlab-ci.yml', '**/*.gitlab-ci.yaml', '**/.gitlab/ci/*.yml', '**/.gitlab/ci/*.yaml'] }),
   ];
 }

--- a/src/extension/pipelines/DataProcessingPipeline.ts
+++ b/src/extension/pipelines/DataProcessingPipeline.ts
@@ -1,5 +1,4 @@
-import { IPipeline } from "./IPipeline";
-import { IParser } from "../parsers/IParser";
+import { IPipeline, ParserWithPatterns } from "./IPipeline";
 import { PipelineType } from "../../shared/types";
 import { AirflowParser } from "../parsers/data-processing/AirflowParser";
 import { KedroParser } from "../parsers/data-processing/KedroParser";
@@ -7,11 +6,9 @@ import { DVCParser } from "../parsers/data-processing/DVCParser";
 
 export class DataProcessingPipeline implements IPipeline {
   type: PipelineType = PipelineType.DataProcessing;
-  parsers: IParser[] = [new AirflowParser(), new KedroParser(), new DVCParser()];
-  patterns: string[] = [
-    '**/dags/*.py',
-    '**/pipeline.py',
-    '**/dvc.yaml',
-    '**/dvc.yml',
+  parsers: ParserWithPatterns[] = [
+    Object.assign(new AirflowParser(), { patterns: ['**/dags/*.py'] }),
+    Object.assign(new KedroParser(), { patterns: ['**/src/**/pipeline.py', '**/src/**/pipelines/**/pipeline.py'] }),
+    Object.assign(new DVCParser(), { patterns: ['**/dvc.yaml', '**/dvc.yml'] }),
   ];
 }

--- a/src/extension/pipelines/DataProcessingPipeline.ts
+++ b/src/extension/pipelines/DataProcessingPipeline.ts
@@ -3,12 +3,14 @@ import { IParser } from "../parsers/IParser";
 import { PipelineType } from "../../shared/types";
 import { AirflowParser } from "../parsers/data-processing/AirflowParser";
 import { KedroParser } from "../parsers/data-processing/KedroParser";
+import { DVCParser } from "../parsers/data-processing/DVCParser";
 
 export class DataProcessingPipeline implements IPipeline {
   type: PipelineType = PipelineType.DataProcessing;
-  parsers: IParser[] = [new AirflowParser(), new KedroParser()];
+  parsers: IParser[] = [new AirflowParser(), new KedroParser(), new DVCParser()];
   patterns: string[] = [
     '**/dags/*.py',
     '**/pipeline.py',
+    '**/dvc.yaml',
   ];
 }

--- a/src/extension/pipelines/DataProcessingPipeline.ts
+++ b/src/extension/pipelines/DataProcessingPipeline.ts
@@ -12,5 +12,6 @@ export class DataProcessingPipeline implements IPipeline {
     '**/dags/*.py',
     '**/pipeline.py',
     '**/dvc.yaml',
+    '**/dvc.yml',
   ];
 }

--- a/src/extension/pipelines/IPipeline.ts
+++ b/src/extension/pipelines/IPipeline.ts
@@ -1,8 +1,11 @@
 import { IParser } from "../parsers/IParser";
 import { PipelineType } from "../../shared/types";
 
+export interface ParserWithPatterns extends IParser {
+  patterns: string[];
+}
+
 export interface IPipeline {
   type: PipelineType;
-  parsers: IParser[];
-  patterns: string[];
+  parsers: ParserWithPatterns[];
 }

--- a/src/extension/pipelines/RPAPipeline.ts
+++ b/src/extension/pipelines/RPAPipeline.ts
@@ -1,12 +1,10 @@
-import { IPipeline } from "./IPipeline";
-import { IParser } from "../parsers/IParser";
+import { IPipeline, ParserWithPatterns } from "./IPipeline";
 import { PipelineType } from "../../shared/types";
 import { UiPathParser } from "../parsers/rpa/UiPathParser";
 
 export class RPAPipeline implements IPipeline {
   type: PipelineType = PipelineType.RPA;
-  parsers: IParser[] = [new UiPathParser()];
-  patterns: string[] = [
-    '**/*.xaml', // For UiPath
+  parsers: ParserWithPatterns[] = [
+    Object.assign(new UiPathParser(), { patterns: ['**/*.xaml'] }),
   ];
 }

--- a/src/webview/PipelineCanvas.tsx
+++ b/src/webview/PipelineCanvas.tsx
@@ -45,8 +45,8 @@ const getLayoutedElements = (nodes: any[], edges: any[], direction = 'TB') => {
 
     nodes.forEach((node) => {
         const isArtifact = node.data?.type === 'artifact';
-        const w = isArtifact ? 220 : nodeWidth;
-        const h = isArtifact ? 60 : nodeHeight;
+        const w = isArtifact ? 180 : nodeWidth;
+        const h = isArtifact ? 36 : nodeHeight;
         dagreGraph.setNode(node.id, { width: w, height: h });
     });
 
@@ -58,8 +58,8 @@ const getLayoutedElements = (nodes: any[], edges: any[], direction = 'TB') => {
 
     const layoutedNodes = nodes.map((node) => {
         const isArtifact = node.data?.type === 'artifact';
-        const w = isArtifact ? 220 : nodeWidth;
-        const h = isArtifact ? 60 : nodeHeight;
+        const w = isArtifact ? 180 : nodeWidth;
+        const h = isArtifact ? 36 : nodeHeight;
         const nodeWithPosition = dagreGraph.node(node.id);
         return {
             ...node,

--- a/src/webview/PipelineCanvas.tsx
+++ b/src/webview/PipelineCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { toPng } from 'html-to-image';
 import ReactFlow, {
     Background,
@@ -44,7 +44,10 @@ const getLayoutedElements = (nodes: any[], edges: any[], direction = 'TB') => {
     dagreGraph.setGraph({ rankdir: direction });
 
     nodes.forEach((node) => {
-        dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+        const isArtifact = node.data?.type === 'artifact';
+        const w = isArtifact ? 220 : nodeWidth;
+        const h = isArtifact ? 60 : nodeHeight;
+        dagreGraph.setNode(node.id, { width: w, height: h });
     });
 
     edges.forEach((edge) => {
@@ -54,12 +57,15 @@ const getLayoutedElements = (nodes: any[], edges: any[], direction = 'TB') => {
     dagre.layout(dagreGraph);
 
     const layoutedNodes = nodes.map((node) => {
+        const isArtifact = node.data?.type === 'artifact';
+        const w = isArtifact ? 220 : nodeWidth;
+        const h = isArtifact ? 60 : nodeHeight;
         const nodeWithPosition = dagreGraph.node(node.id);
         return {
             ...node,
             position: {
-                x: nodeWithPosition.x - nodeWidth / 2,
-                y: nodeWithPosition.y - nodeHeight / 2,
+                x: nodeWithPosition.x - w / 2,
+                y: nodeWithPosition.y - h / 2,
             },
         };
     });
@@ -84,22 +90,22 @@ export const PipelineCanvas: React.FC<PipelineCanvasProps> = ({ data, availableP
     const [activeCategory, setActiveCategory] = useState<string>('cicd');
 
     const {
-      selectionManager,
-      selectionState,
-      selectionBox,
-      setSelectionBox,
-      handleCanvasClick,
-      toggleSelectionMode,
+        selectionManager,
+        selectionState,
+        selectionBox,
+        setSelectionBox,
+        handleCanvasClick,
+        toggleSelectionMode,
     } = useSelection(data.nodes);
 
     const {
-      annotations,
-      editingAnnotationId,
-      selectorPosition,
-      setSelectorPosition,
-      handlePatternSelect,
-      handleDeleteAnnotation,
-      handleEditAnnotation,
+        annotations,
+        editingAnnotationId,
+        selectorPosition,
+        setSelectorPosition,
+        handlePatternSelect,
+        handleDeleteAnnotation,
+        handleEditAnnotation,
     } = useAnnotations(onNotify, selectionManager);
 
     const handleCategorySelect = (category: string) => {
@@ -159,11 +165,13 @@ export const PipelineCanvas: React.FC<PipelineCanvasProps> = ({ data, availableP
     useEffect(() => {
         const initialNodes = data.nodes.map(n => ({
             id: n.id,
-            type: 'custom', // Use our custom node
+            type: 'custom',
             data: {
                 label: n.label,
                 status: n.status,
-                framework: data.framework // Pass framework to node
+                framework: data.framework,
+                type: n.type,
+                ...n.data
             },
             position: { x: 0, y: 0 },
         }));

--- a/src/webview/components/PipelineNodeItem.tsx
+++ b/src/webview/components/PipelineNodeItem.tsx
@@ -1,67 +1,167 @@
 import { Handle, Position, NodeProps } from 'reactflow';
 import {
-    CheckCircle,
-    XCircle,
-    Clock,
-    Terminal,
-    GitBranch
+  CheckCircle,
+  XCircle,
+  Clock,
+  Terminal,
+  GitBranch
 } from 'lucide-react';
 import { SiGithub, SiGitlab, SiDvc } from 'react-icons/si';
+import { FiDatabase } from 'react-icons/fi';
+import { LuImage, LuTable2, LuVideo, LuMusic4 } from 'react-icons/lu';
 
-export const PipelineNodeItem = ({ data }: NodeProps) => {
-    const { layoutDirection = 'TB', isSelectionMode = false, isSelected = false } = data;
+export const PipelineNodeItem = ({ data, id }: NodeProps) => {
+  const { layoutDirection = 'TB', isSelectionMode = false, isSelected = false, type } = data;
 
-    const targetPosition = layoutDirection === 'LR' ? Position.Left : Position.Top;
-    const sourcePosition = layoutDirection === 'LR' ? Position.Right : Position.Bottom;
+  const targetPosition = layoutDirection === 'LR' ? Position.Left : Position.Top;
+  const sourcePosition = layoutDirection === 'LR' ? Position.Right : Position.Bottom;
 
-    // Determine icon based on status or type if available
-    const getStatusIcon = () => {
-        switch (data.status) {
-            case 'success': return <CheckCircle size={16} color="#4ade80" />;
-            case 'failed': return <XCircle size={16} color="#ef4444" />;
-            case 'running': return <Clock size={16} color="#3b82f6" />;
-            default: return <Terminal size={16} color="#a0aec0" />;
-        }
-    };
+  const isArtifact = type === 'artifact';
 
+  // Determine icon based on status or type if available
+  const getStatusIcon = () => {
+    switch (data.status) {
+      case 'success': return <CheckCircle size={16} color="#4ade80" />;
+      case 'failed': return <XCircle size={16} color="#ef4444" />;
+      case 'running': return <Clock size={16} color="#3b82f6" />;
+      default: return <Terminal size={16} color="#a0aec0" />;
+    }
+  };
+
+  const getDataTypeIcon = (dataType: string) => {
+    switch (dataType) {
+      case 'image': return <LuImage size={12} />;
+      case 'table': return <LuTable2 size={12} />;
+      case 'video': return <LuVideo size={12} />;
+      case 'audio': return <LuMusic4 size={12} />;
+      default: return null;
+    }
+  };
+
+  if (isArtifact) {
     return (
-        <div className={`pipeline-node-item ${isSelectionMode ? 'selection-mode' : ''} ${isSelected ? 'selected' : ''}`}>
-            <Handle type="target" position={targetPosition} className="handle" />
+      <div className={`pipeline-node-item artifact ${isSelectionMode ? 'selection-mode' : ''} ${isSelected ? 'selected' : ''}`}>
+        <Handle type="target" position={targetPosition} className="handle" />
 
-            <div className="node-header">
-                <div className="node-icon">
-                    {getStatusIcon()}
-                </div>
-                <div className="node-title">{data.label}</div>
-            </div>
+        <div className="artifact-content">
+          <div className="artifact-icon">
+            <FiDatabase size={24} />
+          </div>
+          <div className="artifact-info">
+            <div className="artifact-name" title={data.label}>{data.label}</div>
+            {data.dataType && data.dataType !== 'other' && (
+              <div className="artifact-badge">
+                {getDataTypeIcon(data.dataType)}
+                <span>{data.dataType}</span>
+              </div>
+            )}
+          </div>
+        </div>
 
-            <div className="node-body">
-                {data.framework && (
-                    <div className="node-meta">
-                        {(() => {
-                            const framework = data.framework.toLowerCase();
-                            if (framework.includes('github')) {
-                                return <SiGithub size={12} style={{ marginRight: 4 }} />;
-                            }
-                            if (framework.includes('gitlab')) {
-                                return <SiGitlab size={12} style={{ marginRight: 4 }} />;
-                            }
-                            if (framework.includes('dvc')) {
-                                return <SiDvc size={12} style={{ marginRight: 4 }} />;
-                            }
-                            return <GitBranch size={12} style={{ marginRight: 4 }} />;
-                        })()}
-                        <span>{data.framework}</span>
-                    </div>
-                )}
-                <div className="node-status">
-                    {data.status || 'Idle'}
-                </div>
-            </div>
+        <Handle type="source" position={sourcePosition} className="handle" />
 
-            <Handle type="source" position={sourcePosition} className="handle" />
+        <style>{`
+                    .pipeline-node-item.artifact {
+                        width: 220px;
+                        height: 60px;
+                        border-radius: 30px;
+                        display: flex;
+                        align-items: center;
+                        justify-content: flex-start;
+                        padding: 0 20px;
+                        background: var(--color-bg-primary);
+                        border: 2px solid #2b2e3c;
+                        transition: all 0.3s ease;
+                    }
 
-            <style>{`
+                    .artifact-content {
+                        display: flex;
+                        flex-direction: row;
+                        align-items: center;
+                        gap: 12px;
+                        width: 100%;
+                        color: var(--color-text-primary);
+                    }
+
+                    .artifact-icon {
+                        color: var(--color-text-primary);
+                        display: flex;
+                        align-items: center;
+                        opacity: 0.9;
+                    }
+
+                    .artifact-info {
+                        display: flex;
+                        flex-direction: column;
+                        align-items: flex-start;
+                        gap: 2px;
+                        overflow: hidden;
+                    }
+
+                    .artifact-name {
+                        font-size: 14px;
+                        font-weight: 600;
+                        max-width: 140px;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
+
+                    .artifact-badge {
+                        display: flex;
+                        align-items: center;
+                        gap: 4px;
+                        background: rgba(14, 165, 233, 0.1);
+                        border: 1px solid rgba(14, 165, 233, 0.3);
+                        border-radius: 12px;
+                        padding: 1px 6px;
+                        font-size: 9px;
+                        color: #0ea5e9;
+                        text-transform: capitalize;
+                    }
+                `}</style>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`pipeline-node-item ${isSelectionMode ? 'selection-mode' : ''} ${isSelected ? 'selected' : ''}`}>
+      <Handle type="target" position={targetPosition} className="handle" />
+
+      <div className="node-header">
+        <div className="node-icon">
+          {getStatusIcon()}
+        </div>
+        <div className="node-title">{data.label}</div>
+      </div>
+
+      <div className="node-body">
+        {data.framework && (
+          <div className="node-meta">
+            {(() => {
+              const framework = data.framework.toLowerCase();
+              if (framework.includes('github')) {
+                return <SiGithub size={12} style={{ marginRight: 4 }} />;
+              }
+              if (framework.includes('gitlab')) {
+                return <SiGitlab size={12} style={{ marginRight: 4 }} />;
+              }
+              if (framework.includes('dvc')) {
+                return <SiDvc size={12} style={{ marginRight: 4 }} />;
+              }
+              return <GitBranch size={12} style={{ marginRight: 4 }} />;
+            })()}
+            <span>{data.framework}</span>
+          </div>
+        )}
+        <div className="node-status">
+          {data.status || 'Idle'}
+        </div>
+      </div>
+
+      <Handle type="source" position={sourcePosition} className="handle" />
+
+      <style>{`
         .pipeline-node-item {
           background: var(--color-bg-primary);
           color: var(--color-text-primary);
@@ -110,6 +210,10 @@ export const PipelineNodeItem = ({ data }: NodeProps) => {
           pointer-events: none;
           animation: selectedPulse 2s infinite;
         }
+
+        .pipeline-node-item.artifact.selected::after {
+            border-radius: 50%;
+        }
         
         @keyframes selectedPulse {
           0%, 100% { opacity: 1; }
@@ -149,6 +253,6 @@ export const PipelineNodeItem = ({ data }: NodeProps) => {
           border: 2px solid var(--color-bg-primary) !important;
         }
       `}</style>
-        </div>
-    );
+    </div>
+  );
 };

--- a/src/webview/components/PipelineNodeItem.tsx
+++ b/src/webview/components/PipelineNodeItem.tsx
@@ -52,104 +52,113 @@ export const PipelineNodeItem = ({ data, id }: NodeProps) => {
       <div className={`pipeline-node-item artifact ${isSelectionMode ? 'selection-mode' : ''} ${isSelected ? 'selected' : ''}`}>
         <Handle type="target" position={targetPosition} className="handle" />
 
-        <div className="artifact-content">
-          <div className="artifact-icon">
-            <FiDatabase size={24} />
+        <div className="artifact-header">
+          <div className="artifact-header-icon">
+            <FiDatabase size={12} />
           </div>
-          <div className="artifact-info">
-            <div className="artifact-name" title={data.label}>{data.label}</div>
-            {data.dataType && data.dataType !== 'other' && (
-              <div className="artifact-badge">
-                {getDataTypeIcon(data.dataType)}
-                <span>{data.dataType}</span>
-              </div>
-            )}
-            {data.dataType === 'folder' && data.contents && (
-              <div className="folder-preview">
-                {data.contents.map((item: string) => (
-                  <div key={item} className="folder-item">• {item}</div>
-                ))}
-              </div>
-            )}
-          </div>
+          <div className="artifact-name" title={data.label}>{data.label}</div>
+        </div>
+
+        <div className="artifact-body">
+          {data.dataType && data.dataType !== 'other' && (
+            <div className="artifact-badge">
+              {getDataTypeIcon(data.dataType)}
+              <span>{data.dataType}</span>
+            </div>
+          )}
+          {data.dataType === 'folder' && data.contents && (
+            <div className="folder-preview">
+              {data.contents.slice(0, 1).map((item: string) => (
+                <div key={item} className="folder-item">• {item}</div>
+              ))}
+            </div>
+          )}
         </div>
 
         <Handle type="source" position={sourcePosition} className="handle" />
 
         <style>{`
                     .pipeline-node-item.artifact {
-                        width: 220px;
-                        min-height: 60px;
-                        border-radius: 12px;
-                        display: flex;
-                        align-items: center;
-                        justify-content: flex-start;
-                        padding: 10px 20px;
+                        width: 180px;
+                        height: 36px;
+                        border-radius: 18px;
+                        padding: 3px 14px;
                         background: var(--color-bg-primary);
-                        border: 2px solid #2b2e3c;
-                        transition: all 0.3s ease;
-                    }
-
-                    .folder-preview {
-                      font-size: 10px;
-                      color: #a0aec0;
-                      margin-top: 4px;
-                      display: flex;
-                      flex-direction: column;
-                      gap: 2px;
-                    }
-
-                    .folder-item {
-                      white-space: nowrap;
-                      overflow: hidden;
-                      text-overflow: ellipsis;
-                      max-width: 150px;
-                    }
-
-                    .artifact-content {
-                        display: flex;
-                        flex-direction: row;
-                        align-items: center;
-                        gap: 12px;
-                        width: 100%;
-                        color: var(--color-text-primary);
-                    }
-
-                    .artifact-icon {
-                        color: var(--color-text-primary);
-                        display: flex;
-                        align-items: center;
-                        opacity: 0.9;
-                    }
-
-                    .artifact-info {
+                        border: 1px solid var(--color-border);
                         display: flex;
                         flex-direction: column;
-                        align-items: flex-start;
-                        gap: 2px;
+                        transition: all 0.3s ease;
                         overflow: hidden;
                     }
 
-                    .artifact-name {
-                        font-size: 14px;
-                        font-weight: 600;
-                        max-width: 140px;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                    }
-
-                    .artifact-badge {
+                    .artifact-header {
                         display: flex;
                         align-items: center;
                         gap: 4px;
-                        background: rgba(14, 165, 233, 0.1);
-                        border: 1px solid rgba(14, 165, 233, 0.3);
-                        border-radius: 12px;
-                        padding: 1px 6px;
-                        font-size: 9px;
-                        color: #0ea5e9;
+                        padding-bottom: 2px;
+                        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+                        margin-bottom: 2px;
+                        height: 15px;
+                    }
+
+                    .artifact-header-icon {
+                        color: var(--color-text-primary);
+                        display: flex;
+                        align-items: center;
+                        opacity: 0.7;
+                    }
+
+                    .artifact-name {
+                        font-size: 10px;
+                        font-weight: 600;
+                        color: var(--color-text-primary);
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        flex: 1;
+                        line-height: 1;
+                    }
+
+                    .artifact-body {
+                        display: flex;
+                        flex-direction: row;
+                        align-items: center;
+                        gap: 4px;
+                        height: 12px;
+                    }
+
+                    .artifact-badge {
+                        display: inline-flex;
+                        align-items: center;
+                        gap: 2px;
+                        background: rgba(255, 255, 255, 0.03);
+                        border: 1px solid rgba(255, 255, 255, 0.05);
+                        border-radius: 6px;
+                        padding: 0px 4px;
+                        font-size: 7px;
+                        color: #94a3b8;
                         text-transform: capitalize;
+                        width: fit-content;
+                        line-height: 1;
+                    }
+
+                    .folder-preview {
+                        font-size: 7px;
+                        color: #94a3b8;
+                        display: flex;
+                        align-items: center;
+                        line-height: 1;
+                    }
+
+                    .folder-item {
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        max-width: 60px;
+                    }
+
+                    .pipeline-node-item.artifact.selected::after {
+                        border-radius: 18px;
                     }
                 `}</style>
       </div>
@@ -282,7 +291,7 @@ export const PipelineNodeItem = ({ data, id }: NodeProps) => {
         }
 
         .pipeline-node-item.artifact.selected::after {
-            border-radius: 50%;
+            border-radius: 32px;
         }
         
         @keyframes selectedPulse {

--- a/src/webview/components/PipelineNodeItem.tsx
+++ b/src/webview/components/PipelineNodeItem.tsx
@@ -6,7 +6,7 @@ import {
     Terminal,
     GitBranch
 } from 'lucide-react';
-import { SiGithub, SiGitlab } from 'react-icons/si';
+import { SiGithub, SiGitlab, SiDvc } from 'react-icons/si';
 
 export const PipelineNodeItem = ({ data }: NodeProps) => {
     const { layoutDirection = 'TB', isSelectionMode = false, isSelected = false } = data;
@@ -45,6 +45,9 @@ export const PipelineNodeItem = ({ data }: NodeProps) => {
                             }
                             if (framework.includes('gitlab')) {
                                 return <SiGitlab size={12} style={{ marginRight: 4 }} />;
+                            }
+                            if (framework.includes('dvc')) {
+                                return <SiDvc size={12} style={{ marginRight: 4 }} />;
                             }
                             return <GitBranch size={12} style={{ marginRight: 4 }} />;
                         })()}

--- a/src/webview/components/TopPanel.tsx
+++ b/src/webview/components/TopPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Workflow, Database, Sparkle, Bot } from 'lucide-react';
+import { Workflow, Sparkle, Bot, Activity } from 'lucide-react';
 
 interface TopPanelProps {
     onCategorySelect: (category: string) => void;
@@ -18,7 +18,7 @@ export const TopPanel: React.FC<TopPanelProps> = ({ onCategorySelect, activeCate
 
     const contexts = [
         { id: 'cicd', icon: Workflow, label: 'CI/CD' },
-        { id: 'data-processing', icon: Database, label: 'Data Processing' },
+        { id: 'data-processing', icon: Activity, label: 'Data Processing' },
         { id: 'ai-agent', icon: Sparkle, label: 'AI Agent' },
         { id: 'rpa', icon: Bot, label: 'Automation' },
     ];

--- a/tests/DVCParser.test.ts
+++ b/tests/DVCParser.test.ts
@@ -1,0 +1,187 @@
+
+import { DVCParser } from '../src/extension/parsers/data-processing/DVCParser';
+import * as path from 'path';
+
+// Mock dependencies
+jest.mock('fs');
+jest.mock('child_process');
+jest.mock('vscode');
+
+describe('DVCParser', () => {
+    let parser: DVCParser;
+    const cwd = '/test/cwd';
+
+    beforeEach(() => {
+        parser = new DVCParser();
+        jest.clearAllMocks();
+    });
+
+    describe('buildStageMaps', () => {
+        it('should correctly map stages to outputs and dependencies', () => {
+            const lockData = {
+                stages: {
+                    prepare: {
+                        outs: [{ path: 'data/prepared' }],
+                        deps: [{ path: 'data/raw' }]
+                    },
+                    train: {
+                        outs: [{ path: 'model.pkl' }],
+                        deps: [{ path: 'data/prepared' }]
+                    }
+                }
+            };
+
+            const result = parser.buildStageMaps(lockData);
+
+            expect(result.stageToOutputs.get('prepare')).toEqual(['data/prepared']);
+            expect(result.stageToOutputs.get('train')).toEqual(['model.pkl']);
+            expect(result.stageToDeps.get('prepare')).toEqual(['data/raw']);
+            expect(result.stageToDeps.get('train')).toEqual(['data/prepared']);
+            expect(result.outputToProducer.get('data/prepared')).toEqual('prepare');
+            expect(result.outputToProducer.get('model.pkl')).toEqual('train');
+        });
+
+        it('should handle missing stages or empty data', () => {
+            const result = parser.buildStageMaps({});
+            expect(result.stageToOutputs.size).toBe(0);
+            expect(result.stageToDeps.size).toBe(0);
+        });
+    });
+
+    describe('buildStageAndArtifactNodes', () => {
+        it('should create nodes for stages and their output artifacts', () => {
+            const mermaid = `
+                flowchart TD
+                node1["prepare"]
+                node2["train"]
+            `;
+
+            const stageToOutputs = new Map([
+                ['prepare', ['data/prepared.csv']],
+                ['train', ['model.pkl']]
+            ]);
+            const stageToDeps = new Map([
+                ['prepare', ['data/raw.csv']],
+                ['train', ['data/prepared.csv']]
+            ]);
+            const paramsData = {};
+
+            const { nodes, artifactByPath } = parser.buildStageAndArtifactNodes(
+                mermaid,
+                stageToOutputs,
+                stageToDeps,
+                paramsData,
+                cwd
+            );
+
+            // Should have 4 nodes: 2 stages + 2 artifacts
+            expect(nodes.length).toBe(4);
+
+            const prepareNode = nodes.find(n => n.id === 'node1');
+            expect(prepareNode).toBeDefined();
+            expect(prepareNode?.label).toBe('prepare');
+
+            const artifactNode = nodes.find(n => n.label === 'data/prepared.csv');
+            expect(artifactNode).toBeDefined();
+            expect(artifactNode?.type).toBe('artifact');
+
+            expect(artifactByPath.get('data/prepared.csv')).toBeDefined();
+            expect(artifactByPath.get('model.pkl')).toBeDefined();
+        });
+
+        it('should categorise artifacts correctly', () => {
+            const mermaid = `
+                flowchart TD
+                node1["prepare"]
+            `;
+            const stageToOutputs = new Map([
+                ['prepare', ['image.png', 'data.csv', 'model.pkl', 'folder']]
+            ]);
+
+            const { nodes } = parser.buildStageAndArtifactNodes(
+                mermaid,
+                stageToOutputs,
+                new Map(),
+                {},
+                cwd
+            );
+
+            const imgNode = nodes.find(n => n.label === 'image.png');
+            expect(imgNode?.data.dataType).toBe('image');
+
+            const csvNode = nodes.find(n => n.label === 'data.csv');
+            expect(csvNode?.data.dataType).toBe('table');
+
+            const folderNode = nodes.find(n => n.label === 'folder');
+            expect(folderNode?.data.dataType).toBe('folder');
+        });
+    });
+
+    describe('buildEdges', () => {
+        it('should link stages via artifacts when possible', () => {
+            const mermaid = `
+                flowchart TD
+                node1["prepare"]
+                node2["train"]
+                node1 --> node2
+            `;
+
+            // Reconstruct minimal nodes needed
+            const nodes = [
+                { id: 'node1', label: 'prepare', type: 'default', data: { framework: 'DVC' } },
+                { id: 'node2', label: 'train', type: 'default', data: { framework: 'DVC' } },
+                // artifact node
+                { id: 'art-node1-0', label: 'data/prepared.csv', type: 'artifact', data: { dataType: 'table' } }
+            ] as any[];
+
+            const artifactByPath = new Map<string, any>();
+            artifactByPath.set('data/prepared.csv', nodes[2]);
+
+            const stageToOutputs = new Map([['prepare', ['data/prepared.csv']]]);
+            const stageToDeps = new Map([['train', ['data/prepared.csv']]]);
+
+            const edges = parser.buildEdges(
+                mermaid,
+                nodes,
+                stageToOutputs,
+                stageToDeps,
+                artifactByPath
+            );
+
+            // Expected edges:
+            // 1. prepare -> artifact (added implicitly by checking outputs)
+            // 2. artifact -> train (because train depends on it)
+
+            const sourceToArtifact = edges.find(e => e.source === 'node1' && e.target === 'art-node1-0');
+            const artifactToTarget = edges.find(e => e.source === 'art-node1-0' && e.target === 'node2');
+
+            expect(sourceToArtifact).toBeDefined();
+            expect(artifactToTarget).toBeDefined();
+        });
+
+        it('should fallback to direct edge if no common artifact', () => {
+            const mermaid = `
+                flowchart TD
+                node1["prepare"]
+                node2["train"]
+                node1 --> node2
+            `;
+            const nodes = [
+                { id: 'node1', label: 'prepare', type: 'default', data: { framework: 'DVC' } },
+                { id: 'node2', label: 'train', type: 'default', data: { framework: 'DVC' } }
+            ] as any[];
+
+            const edges = parser.buildEdges(
+                mermaid,
+                nodes,
+                new Map(),
+                new Map(),
+                new Map()
+            );
+
+            expect(edges.length).toBe(1);
+            expect(edges[0].source).toBe('node1');
+            expect(edges[0].target).toBe('node2');
+        });
+    });
+});

--- a/tests/vscode-mock.ts
+++ b/tests/vscode-mock.ts
@@ -1,0 +1,21 @@
+
+export const workspace = {
+    getWorkspaceFolder: jest.fn(),
+    workspaceFolders: [],
+};
+
+export const window = {
+    showWarningMessage: jest.fn(),
+    showErrorMessage: jest.fn(),
+};
+
+export const Uri = {
+    file: (path: string) => ({ fsPath: path, scheme: 'file' }),
+    parse: (path: string) => ({ fsPath: path, scheme: 'file' }),
+};
+
+export enum ExtensionMode {
+    Production = 1,
+    Development = 2,
+    Test = 3,
+}


### PR DESCRIPTION
This PR adds support for DVC pipelines in Caldera. 

Key changes:
1. **DVCParser**: A new parser that utilizes the DVC CLI (`dvc dag --mermaid`) to extract pipeline structure. It includes a robust CLI detection mechanism that checks for local virtual environments, `uv`, `pipx`, and global `dvc` installations.
2. **Async Parsing**: The `IParser` interface and all existing parsers were updated to be asynchronous to accommodate CLI-based parsing.
3. **UI Integration**: The DVC logo (`SiDvc` from `react-icons/si`) is now displayed for DVC-based nodes in the webview.
4. **User Experience**: If a `dvc.yaml` file is found but the DVC CLI is not available, a warning message is shown to the user.

Verified with frontend screenshots and existing test suite.

---
*PR created automatically by Jules for task [6299618830023415593](https://jules.google.com/task/6299618830023415593) started by @Resmung0*

## Summary by Sourcery

Add support for parsing and visualizing DVC data-processing pipelines via the DVC CLI and integrate it into the existing pipeline discovery flow.

New Features:
- Introduce a DVC pipeline parser that uses the DVC CLI mermaid DAG output to build pipeline graphs.
- Extend the data-processing pipeline configuration to recognize dvc.yaml files as pipeline definitions and associate them with the DVC parser.
- Display a DVC-specific icon for DVC framework nodes in the pipeline webview.

Enhancements:
- Update the generic parser interface and existing parsers to support asynchronous parsing and adapt the extension discovery logic to await parser results.