### PR TITLE
Implement functional GitLab CI parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2416,7 +2415,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3020,7 +3018,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3371,7 +3368,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4129,7 +4125,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5274,7 +5269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5341,7 +5335,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5351,7 +5344,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5906,7 +5898,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6050,7 +6041,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6176,7 +6166,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6270,7 +6259,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/extension/parsers/cicd/GitHubActionsParser.ts
+++ b/src/extension/parsers/cicd/GitHubActionsParser.ts
@@ -7,7 +7,12 @@ export class GitHubActionsParser implements IParser {
 
     canParse(fileName: string, content: string): boolean {
         const normalizedPath = fileName.replace(/\\/g, '/');
-        return normalizedPath.includes('.github/workflows/') &&
+        const segments = normalizedPath.split('/');
+        const workflowsIndex = segments.indexOf('workflows');
+        const githubIndex = segments.indexOf('.github');
+
+        return githubIndex !== -1 &&
+            workflowsIndex === githubIndex + 1 &&
             (normalizedPath.endsWith('.yml') || normalizedPath.endsWith('.yaml'));
     }
 

--- a/src/extension/parsers/cicd/GitHubActionsParser.ts
+++ b/src/extension/parsers/cicd/GitHubActionsParser.ts
@@ -6,7 +6,9 @@ export class GitHubActionsParser implements IParser {
     name = 'GitHub Action';
 
     canParse(fileName: string, content: string): boolean {
-        return fileName.endsWith('.yml') || fileName.endsWith('.yaml');
+        const normalizedPath = fileName.replace(/\\/g, '/');
+        return normalizedPath.includes('.github/workflows/') &&
+            (normalizedPath.endsWith('.yml') || normalizedPath.endsWith('.yaml'));
     }
 
     async parse(content: string, filePath: string): Promise<PipelineData> {

--- a/src/extension/parsers/cicd/GitLabCIParser.ts
+++ b/src/extension/parsers/cicd/GitLabCIParser.ts
@@ -2,6 +2,14 @@ import * as yaml from 'js-yaml';
 import { IParser } from "../IParser";
 import { PipelineData, PipelineNode, PipelineEdge } from "../../../shared/types";
 
+type ParsedJob = {
+  id: string;
+  name: string;
+  stage: string;
+  needs?: (string | { job: string })[];
+  [key: string]: any;
+};
+
 export class GitLabCIParser implements IParser {
   name = "GitLab CI";
 
@@ -12,9 +20,20 @@ export class GitLabCIParser implements IParser {
 
   canParse(fileName: string, content: string): boolean {
     const normalizedPath = fileName.replace(/\\/g, '/');
-    return normalizedPath.endsWith(".gitlab-ci.yml") ||
-      normalizedPath.endsWith(".gitlab-ci.yaml") ||
-      normalizedPath.includes(".gitlab/ci/");
+    const segments = normalizedPath.split('/');
+
+    if (segments.some(s => s === '.gitlab-ci.yml' || s === '.gitlab-ci.yaml')) {
+      return true;
+    }
+
+    const gitlabIndex = segments.indexOf('.gitlab');
+    const ciIndex = segments.indexOf('ci');
+    if (gitlabIndex !== -1 && ciIndex === gitlabIndex + 1 &&
+      (normalizedPath.endsWith('.yml') || normalizedPath.endsWith('.yaml'))) {
+      return true;
+    }
+
+    return false;
   }
 
   async parse(content: string, filePath: string): Promise<PipelineData> {
@@ -24,76 +43,16 @@ export class GitLabCIParser implements IParser {
         return { filePath, framework: this.name, nodes: [], edges: [] };
       }
 
-      const nodes: PipelineNode[] = [];
+      const stages = Array.isArray(doc.stages) ? doc.stages : ['.pre', 'build', 'test', 'deploy', '.post'];
+
+      const jobs = this.getJobsFromDoc(doc);
+      const nodes = this.buildNodesFromJobs(jobs);
       const edges: PipelineEdge[] = [];
 
-      const stages = Array.isArray(doc.stages) ? doc.stages : ['.pre', 'build', 'test', 'deploy', '.post'];
-      const jobs: any[] = [];
+      const jobIds = new Set(jobs.map(j => j.id));
 
-      // 1. Identify jobs
-      Object.keys(doc).forEach(key => {
-        if (this.reservedKeywords.includes(key) || key.startsWith('.')) {
-          return;
-        }
-
-        const job = doc[key];
-        if (job && typeof job === 'object') {
-          const stage = job.stage || 'test';
-          const jobInfo = { id: key, name: key, stage, ...job };
-          jobs.push(jobInfo);
-          nodes.push({
-            id: key,
-            label: key,
-            type: 'default',
-            data: {
-              stage: stage
-            }
-          });
-        }
-      });
-
-      // 2. Extract explicit dependencies (needs)
-      jobs.forEach(job => {
-        if (job.needs && Array.isArray(job.needs)) {
-          job.needs.forEach((need: any) => {
-            const needId = typeof need === 'string' ? need : need.job;
-            if (needId) {
-              edges.push({
-                id: `e-${needId}-${job.id}`,
-                source: needId,
-                target: job.id
-              });
-            }
-          });
-        }
-      });
-
-      // 3. Extract implicit stage dependencies if no "needs" are present for the job
-      // GitLab default behavior: a job depends on all jobs in previous stages if "needs" is not specified.
-      // If "needs" is defined (even if empty: []), it overrides the default behavior.
-      // We look for the nearest previous stage that has jobs.
-      jobs.forEach(job => {
-        const hasNeeds = job.needs !== undefined;
-        if (!hasNeeds) {
-          const currentStageIndex = stages.indexOf(job.stage);
-          if (currentStageIndex > 0) {
-            for (let i = currentStageIndex - 1; i >= 0; i--) {
-              const previousStage = stages[i];
-              const previousStageJobs = jobs.filter(j => j.stage === previousStage);
-              if (previousStageJobs.length > 0) {
-                previousStageJobs.forEach(prevJob => {
-                  edges.push({
-                    id: `e-stage-${prevJob.id}-${job.id}`,
-                    source: prevJob.id,
-                    target: job.id
-                  });
-                });
-                break; // Found the nearest previous stage with jobs
-              }
-            }
-          }
-        }
-      });
+      this.buildNeedsEdges(jobs, jobIds, edges);
+      this.buildStageEdges(jobs, stages, edges);
 
       return {
         filePath,
@@ -103,7 +62,90 @@ export class GitLabCIParser implements IParser {
       };
     } catch (e) {
       console.error('Failed to parse GitLab CI', e);
-      return { filePath, framework: 'Unknown', nodes: [], edges: [] };
+      return { filePath, framework: this.name, nodes: [], edges: [] };
     }
+  }
+
+  private getJobsFromDoc(doc: any): ParsedJob[] {
+    const jobs: ParsedJob[] = [];
+
+    Object.keys(doc).forEach(key => {
+      if (this.reservedKeywords.includes(key) || key.startsWith('.')) {
+        return;
+      }
+
+      const job = doc[key];
+      if (job && typeof job === 'object' && !Array.isArray(job)) {
+        const stage = job.stage || 'test';
+        jobs.push({ id: key, name: key, stage, ...job });
+      }
+    });
+
+    return jobs;
+  }
+
+  private buildNodesFromJobs(jobs: ParsedJob[]): PipelineNode[] {
+    return jobs.map(job => ({
+      id: job.id,
+      label: job.id,
+      type: 'default',
+      data: {
+        stage: job.stage
+      }
+    }));
+  }
+
+  private buildNeedsEdges(jobs: ParsedJob[], jobIds: Set<string>, edges: PipelineEdge[]): void {
+    jobs.forEach(job => {
+      if (job.needs && Array.isArray(job.needs)) {
+        job.needs.forEach((need: any) => {
+          const needId = typeof need === 'string' ? need : need.job;
+          if (needId && jobIds.has(needId)) {
+            edges.push({
+              id: `e-${needId}-${job.id}`,
+              source: needId,
+              target: job.id
+            });
+          }
+        });
+      }
+    });
+  }
+
+  private buildStageEdges(jobs: ParsedJob[], stages: string[], edges: PipelineEdge[]): void {
+    const stageIndex = new Map<string, number>();
+    stages.forEach((stage, index) => stageIndex.set(stage, index));
+
+    const jobsByStage = new Map<string, ParsedJob[]>();
+    jobs.forEach(job => {
+      const list = jobsByStage.get(job.stage) ?? [];
+      list.push(job);
+      jobsByStage.set(job.stage, list);
+    });
+
+    jobs.forEach(job => {
+      const hasNeeds = job.needs !== undefined;
+      if (hasNeeds) return;
+
+      const currentIndex = stageIndex.get(job.stage);
+      if (currentIndex === undefined || currentIndex <= 0) return;
+
+      // GitLab default behavior: a job depends on all jobs in ALL previous stages if "needs" is not specified.
+      for (let i = currentIndex - 1; i >= 0; i--) {
+        const previousStage = stages[i];
+        const previousStageJobs = jobsByStage.get(previousStage) ?? [];
+
+        previousStageJobs.forEach(prevJob => {
+          edges.push({
+            id: `e-stage-${prevJob.id}-${job.id}`,
+            source: prevJob.id,
+            target: job.id
+          });
+        });
+
+        // Per review comment 1, we do NOT break here to include all previous stages.
+        // Note: This may create redundant edges in linear pipelines.
+      }
+    });
   }
 }

--- a/src/extension/parsers/cicd/GitLabCIParser.ts
+++ b/src/extension/parsers/cicd/GitLabCIParser.ts
@@ -1,20 +1,109 @@
+import * as yaml from 'js-yaml';
 import { IParser } from "../IParser";
-import { PipelineData } from "../../../shared/types";
+import { PipelineData, PipelineNode, PipelineEdge } from "../../../shared/types";
 
 export class GitLabCIParser implements IParser {
   name = "GitLab CI";
 
+  private readonly reservedKeywords = [
+    'image', 'services', 'stages', 'types', 'before_script',
+    'after_script', 'variables', 'cache', 'include', 'workflow', 'default'
+  ];
+
   canParse(fileName: string, content: string): boolean {
-    return fileName.endsWith(".gitlab-ci.yml");
+    const normalizedPath = fileName.replace(/\\/g, '/');
+    return normalizedPath.endsWith(".gitlab-ci.yml") ||
+      normalizedPath.endsWith(".gitlab-ci.yaml") ||
+      normalizedPath.includes(".gitlab/ci/");
   }
 
   async parse(content: string, filePath: string): Promise<PipelineData> {
-    // Placeholder implementation
-    return {
-      filePath,
-      framework: this.name,
-      nodes: [],
-      edges: [],
-    };
+    try {
+      const doc = yaml.load(content) as any;
+      if (!doc || typeof doc !== 'object') {
+        return { filePath, framework: this.name, nodes: [], edges: [] };
+      }
+
+      const nodes: PipelineNode[] = [];
+      const edges: PipelineEdge[] = [];
+
+      const stages = Array.isArray(doc.stages) ? doc.stages : ['.pre', 'build', 'test', 'deploy', '.post'];
+      const jobs: any[] = [];
+
+      // 1. Identify jobs
+      Object.keys(doc).forEach(key => {
+        if (this.reservedKeywords.includes(key) || key.startsWith('.')) {
+          return;
+        }
+
+        const job = doc[key];
+        if (job && typeof job === 'object') {
+          const stage = job.stage || 'test';
+          const jobInfo = { id: key, name: key, stage, ...job };
+          jobs.push(jobInfo);
+          nodes.push({
+            id: key,
+            label: key,
+            type: 'default',
+            data: {
+              stage: stage
+            }
+          });
+        }
+      });
+
+      // 2. Extract explicit dependencies (needs)
+      jobs.forEach(job => {
+        if (job.needs && Array.isArray(job.needs)) {
+          job.needs.forEach((need: any) => {
+            const needId = typeof need === 'string' ? need : need.job;
+            if (needId) {
+              edges.push({
+                id: `e-${needId}-${job.id}`,
+                source: needId,
+                target: job.id
+              });
+            }
+          });
+        }
+      });
+
+      // 3. Extract implicit stage dependencies if no "needs" are present for the job
+      // GitLab default behavior: a job depends on all jobs in previous stages if "needs" is not specified.
+      // If "needs" is defined (even if empty: []), it overrides the default behavior.
+      // We look for the nearest previous stage that has jobs.
+      jobs.forEach(job => {
+        const hasNeeds = job.needs !== undefined;
+        if (!hasNeeds) {
+          const currentStageIndex = stages.indexOf(job.stage);
+          if (currentStageIndex > 0) {
+            for (let i = currentStageIndex - 1; i >= 0; i--) {
+              const previousStage = stages[i];
+              const previousStageJobs = jobs.filter(j => j.stage === previousStage);
+              if (previousStageJobs.length > 0) {
+                previousStageJobs.forEach(prevJob => {
+                  edges.push({
+                    id: `e-stage-${prevJob.id}-${job.id}`,
+                    source: prevJob.id,
+                    target: job.id
+                  });
+                });
+                break; // Found the nearest previous stage with jobs
+              }
+            }
+          }
+        }
+      });
+
+      return {
+        filePath,
+        framework: this.name,
+        nodes,
+        edges,
+      };
+    } catch (e) {
+      console.error('Failed to parse GitLab CI', e);
+      return { filePath, framework: 'Unknown', nodes: [], edges: [] };
+    }
   }
 }

--- a/tests/GitHubActionsParser.test.ts
+++ b/tests/GitHubActionsParser.test.ts
@@ -1,0 +1,20 @@
+import { GitHubActionsParser } from '../src/extension/parsers/cicd/GitHubActionsParser';
+
+describe('GitHubActionsParser', () => {
+    let parser: GitHubActionsParser;
+
+    beforeEach(() => {
+        parser = new GitHubActionsParser();
+    });
+
+    it('should identify GitHub Action files', () => {
+        expect(parser.canParse('.github/workflows/main.yml', '')).toBe(true);
+        expect(parser.canParse('.github/workflows/deploy.yaml', '')).toBe(true);
+        expect(parser.canParse('/abs/path/.github/workflows/test.yml', '')).toBe(true);
+
+        expect(parser.canParse('workflows/main.yml', '')).toBe(false);
+        expect(parser.canParse('.github/main.yml', '')).toBe(false);
+        expect(parser.canParse('.github/workflows/readme.md', '')).toBe(false);
+        expect(parser.canParse('other.yml', '')).toBe(false);
+    });
+});

--- a/tests/GitLabCIParser.test.ts
+++ b/tests/GitLabCIParser.test.ts
@@ -1,0 +1,117 @@
+import { GitLabCIParser } from '../src/extension/parsers/cicd/GitLabCIParser';
+
+describe('GitLabCIParser', () => {
+  let parser: GitLabCIParser;
+
+  beforeEach(() => {
+    parser = new GitLabCIParser();
+  });
+
+  it('should identify .gitlab-ci.yml files', () => {
+    expect(parser.canParse('.gitlab-ci.yml', '')).toBe(true);
+    expect(parser.canParse('.gitlab-ci.yaml', '')).toBe(true);
+    expect(parser.canParse('.gitlab/ci/build.yml', '')).toBe(true);
+    expect(parser.canParse('other.yml', '')).toBe(false);
+  });
+
+  it('should extract jobs as nodes', async () => {
+    const yaml = `
+job1:
+  script: echo "hello"
+job2:
+  script: echo "world"
+`;
+    const result = await parser.parse(yaml, '.gitlab-ci.yml');
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.map(n => n.id)).toContain('job1');
+    expect(result.nodes.map(n => n.id)).toContain('job2');
+  });
+
+  it('should skip reserved keywords', async () => {
+    const yaml = `
+stages:
+  - build
+  - test
+variables:
+  VAR: val
+job1:
+  stage: build
+  script: echo "hello"
+`;
+    const result = await parser.parse(yaml, '.gitlab-ci.yml');
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].id).toBe('job1');
+  });
+
+  it('should extract dependencies from needs', async () => {
+    const yaml = `
+job1:
+  stage: build
+  script: echo "hello"
+job2:
+  stage: test
+  script: echo "world"
+  needs: ["job1"]
+`;
+    const result = await parser.parse(yaml, '.gitlab-ci.yml');
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe('job1');
+    expect(result.edges[0].target).toBe('job2');
+  });
+
+  it('should handle implicit stage dependencies', async () => {
+    const yaml = `
+stages:
+  - build
+  - test
+job1:
+  stage: build
+  script: echo "hello"
+job2:
+  stage: test
+  script: echo "world"
+`;
+    const result = await parser.parse(yaml, '.gitlab-ci.yml');
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe('job1');
+    expect(result.edges[0].target).toBe('job2');
+  });
+
+  it('should skip empty stages when calculating implicit dependencies', async () => {
+    const yaml = `
+stages:
+  - build
+  - test
+  - deploy
+job1:
+  stage: build
+  script: echo "hello"
+job3:
+  stage: deploy
+  script: echo "world"
+`;
+    const result = await parser.parse(yaml, '.gitlab-ci.yml');
+    // job3 should depend on job1 because test stage is empty
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe('job1');
+    expect(result.edges[0].target).toBe('job3');
+  });
+
+  it('should not add implicit dependencies if needs is an empty array', async () => {
+    const yaml = `
+stages:
+  - build
+  - test
+job1:
+  stage: build
+  script: echo "hello"
+job2:
+  stage: test
+  script: echo "world"
+  needs: []
+`;
+    const result = await parser.parse(yaml, '.gitlab-ci.yml');
+    // job2 has needs: [], so it should have NO edges
+    expect(result.edges).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
This change updates the GitLab CI parser from a placeholder to a functional implementation that can extract jobs and dependencies from .gitlab-ci.yml files. It handles both explicit 'needs' dependencies and GitLab's default implicit stage-based dependencies. Additionally, it refines the 'canParse' logic for both GitHub Actions and GitLab CI parsers to ensure they only match relevant files based on their directory structure, preventing overlap.

---
*PR created automatically by Jules for task [8381528433909715993](https://jules.google.com/task/8381528433909715993) started by @Resmung0*

## Summary by Sourcery

Implement a functional GitLab CI pipeline parser and tighten CI config detection for GitHub Actions and GitLab CI files.

New Features:
- Add a GitLab CI parser that extracts jobs, stages, and dependencies from .gitlab-ci configuration files.

Enhancements:
- Refine GitHub Actions parser file matching to only consider workflows under the .github/workflows directory.
- Broaden GitLab CI parser file matching to support multiple standard GitLab CI locations and extensions.

Build:
- Update npm lockfile to include the YAML parsing dependency used by the GitLab CI parser.

Tests:
- Add unit tests covering GitLab CI parsing of jobs, stages, and dependency resolution.