### PR TITLE
Support for latest Airflow pipelines (TaskFlow & Classic)

### DIFF
--- a/src/extension/parsers/data-processing/AirflowParser.ts
+++ b/src/extension/parsers/data-processing/AirflowParser.ts
@@ -1,11 +1,12 @@
 import { IParser } from "../IParser";
-import { PipelineData, PipelineNode, PipelineEdge } from "../../../shared/types";
+import { PipelineData, PipelineNode, PipelineEdge, CodeSnippet } from "../../../shared/types";
 import * as fs from 'fs';
 import * as path from 'path';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 
 const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 interface CommandInfo {
   command: string;
@@ -26,30 +27,41 @@ export class AirflowParser implements IParser {
     const cwd = path.dirname(filePath);
     const airflowInfo = await this.getAirflowCmd(cwd);
 
-    if (airflowInfo) {
-      try {
-        const dagId = this.extractDagId(content);
-        if (dagId) {
-          const data = await this.parseWithCLI(dagId, filePath, airflowInfo.commandInfo, cwd);
-          // Enrich with snippets from local content
-          data.nodes = data.nodes.map(node => ({
-            ...node,
-            data: {
-              ...node.data,
-              codeDeps: [
-                ...this.extractTaskSnippet(content, node.id),
-                ...this.extractOperatorSnippet(content, node.id)
-              ].slice(0, 1) // Take the first match
-            }
-          }));
-          return data;
-        }
-      } catch (error) {
-        console.error("Airflow CLI parsing failed, falling back to regex:", error);
-      }
-    }
+    const cliResult = airflowInfo
+      ? await this.tryParseWithCLI(content, filePath, airflowInfo.commandInfo, cwd)
+      : null;
 
-    return this.parseWithRegex(content, filePath);
+    return cliResult ?? this.parseWithRegex(content, filePath);
+  }
+
+  private async tryParseWithCLI(
+    content: string,
+    filePath: string,
+    cmdInfo: CommandInfo,
+    cwd: string
+  ): Promise<PipelineData | null> {
+    const dagId = this.extractDagId(content);
+    if (!dagId) return null;
+
+    try {
+      const data = await this.parseWithCLI(dagId, filePath, cmdInfo, cwd);
+      data.nodes = data.nodes.map(node => {
+        const taskSnippets = this.extractTaskSnippet(content, filePath, node.id);
+        const opSnippets = this.extractOperatorSnippet(content, filePath, node.id);
+
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            codeDeps: [...taskSnippets, ...opSnippets].slice(0, 1),
+          },
+        };
+      });
+      return data;
+    } catch (error) {
+      console.error("Airflow CLI parsing failed, falling back to regex:", error);
+      return null;
+    }
   }
 
   private extractDagId(content: string): string | null {
@@ -66,8 +78,8 @@ export class AirflowParser implements IParser {
   }
 
   private async parseWithCLI(dagId: string, filePath: string, cmdInfo: CommandInfo, cwd: string): Promise<PipelineData> {
-    const fullCmd = [cmdInfo.command, ...cmdInfo.args, 'dags', 'show', dagId].join(' ');
-    const { stdout } = await execPromise(fullCmd, { cwd });
+    const args = [...cmdInfo.args, 'dags', 'show', dagId];
+    const { stdout } = await execFilePromise(cmdInfo.command, args, { cwd });
 
     if (!stdout || !stdout.includes('digraph')) {
         throw new Error("Invalid DOT output from Airflow CLI");
@@ -122,7 +134,7 @@ export class AirflowParser implements IParser {
         type: 'default',
         data: {
           framework: this.name,
-          codeDeps: this.extractTaskSnippet(content, match[1])
+          codeDeps: this.extractTaskSnippet(content, filePath, match[1])
         }
       });
     }
@@ -132,6 +144,12 @@ export class AirflowParser implements IParser {
     while ((match = operatorRegex.exec(content)) !== null) {
       const varName = match[1];
       const taskId = match[2] || varName;
+
+      const byTaskId = this.extractOperatorSnippet(content, filePath, taskId);
+      const codeDeps = byTaskId.length > 0
+        ? byTaskId
+        : this.extractOperatorSnippetByVar(content, filePath, varName);
+
       nodes.push({
         id: taskId,
         label: taskId,
@@ -139,7 +157,7 @@ export class AirflowParser implements IParser {
         data: {
           framework: this.name,
           variableName: varName,
-          codeDeps: this.extractOperatorSnippet(content, taskId) || this.extractOperatorSnippetByVar(content, varName)
+          codeDeps
         }
       });
     }
@@ -190,58 +208,65 @@ export class AirflowParser implements IParser {
     };
   }
 
-  private extractTaskSnippet(content: string, taskId: string): any[] {
+  private findLineIndex(lines: string[], predicate: (line: string, idx: number) => boolean): number {
+    return lines.findIndex(predicate);
+  }
+
+  private getIndentedBlock(lines: string[], headerIdx: number): { start: number; end: number } {
+    const defIdx = lines.findIndex((line, i) => i >= headerIdx && line.includes('def ') && !line.trim().startsWith('#'));
+    if (defIdx === -1) return { start: headerIdx, end: headerIdx };
+
+    const startIndent = lines[defIdx].search(/\S/);
+    let endIdx = defIdx;
+
+    for (let i = defIdx + 1; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (trimmed === '' || trimmed.startsWith('#')) {
+        endIdx = i;
+        continue;
+      }
+      const currentIndent = lines[i].search(/\S/);
+      if (currentIndent <= startIndent && currentIndent !== -1) break;
+      endIdx = i;
+    }
+
+    return { start: headerIdx, end: endIdx };
+  }
+
+  private extractTaskSnippet(content: string, filePath: string, taskId: string): CodeSnippet[] {
     const lines = content.split('\n');
-    const startIdx = lines.findIndex((line, idx) =>
-        line.includes(`@task`) &&
-        (lines[idx + 1]?.includes(`def ${taskId}`) || lines[idx + 2]?.includes(`def ${taskId}`))
+    const startIdx = this.findLineIndex(
+      lines,
+      (line, idx) =>
+        line.includes('@task') &&
+        (lines[idx + 1]?.includes(`def ${taskId}`) || lines[idx + 2]?.includes(`def ${taskId}`)),
     );
     if (startIdx === -1) return [];
 
-    let endIdx = startIdx + 1;
-    for (let i = startIdx + 1; i < lines.length; i++) {
-        if (lines[i].includes(`def ${taskId}`)) {
-            const startIndent = lines[i].search(/\S/);
-            for (let j = i + 1; j < lines.length; j++) {
-                if (lines[j].trim() !== '' && !lines[j].trim().startsWith('#')) {
-                    const currentIndent = lines[j].search(/\S/);
-                    if (currentIndent <= startIndent && currentIndent !== -1) {
-                        endIdx = j - 1;
-                        break;
-                    }
-                }
-                endIdx = j;
-            }
-            break;
-        }
-    }
-
-    return [{
-      path: 'dag.py',
-      snippet: lines.slice(startIdx, endIdx + 1).join('\n')
-    }];
+    const { start, end } = this.getIndentedBlock(lines, startIdx);
+    return [{ path: filePath, snippet: lines.slice(start, end + 1).join('\n') }];
   }
 
-  private extractOperatorSnippet(content: string, taskId: string): any[] {
+  private extractOperatorSnippet(content: string, filePath: string, taskId: string): CodeSnippet[] {
     const lines = content.split('\n');
-    const lineIdx = lines.findIndex(line => line.includes(`task_id=["']${taskId}["']`) || line.includes(`task_id = ["']${taskId}["']`));
+    const lineIdx = this.findLineIndex(
+      lines,
+      line =>
+        line.includes(`task_id=["']${taskId}["']`) ||
+        line.includes(`task_id = ["']${taskId}["']`),
+    );
     if (lineIdx === -1) return [];
-
-    return [{
-      path: 'dag.py',
-      snippet: lines[lineIdx].trim()
-    }];
+    return [{ path: filePath, snippet: lines[lineIdx].trim() }];
   }
 
-  private extractOperatorSnippetByVar(content: string, varName: string): any[] {
+  private extractOperatorSnippetByVar(content: string, filePath: string, varName: string): CodeSnippet[] {
     const lines = content.split('\n');
-    const lineIdx = lines.findIndex(line => line.includes(`${varName} =`) && line.includes('Operator'));
+    const lineIdx = this.findLineIndex(
+      lines,
+      line => line.includes(`${varName} =`) && line.includes('Operator'),
+    );
     if (lineIdx === -1) return [];
-
-    return [{
-      path: 'dag.py',
-      snippet: lines[lineIdx].trim()
-    }];
+    return [{ path: filePath, snippet: lines[lineIdx].trim() }];
   }
 
   private async getAirflowCmd(cwd: string): Promise<{ commandInfo: CommandInfo; isLocal: boolean } | null> {
@@ -249,43 +274,48 @@ export class AirflowParser implements IParser {
       return this.airflowCmdCache.get(cwd)!;
     }
 
-    const isWindows = process.platform === 'win32';
-    const venvDirs = ['.venv', 'venv', 'env'];
-    const venvPaths: string[] = [];
-    for (const dir of venvDirs) {
-      venvPaths.push(
-        path.join(cwd, dir, isWindows ? 'Scripts' : 'bin', isWindows ? 'airflow.exe' : 'airflow')
-      );
-    }
+    let result = this.findVenvAirflow(cwd)
+      ?? await this.findUvAirflow(cwd)
+      ?? await this.findGlobalAirflow();
 
-    let commandInfo: CommandInfo | null = null;
-    let isLocal = false;
-
-    for (const venvAirflow of venvPaths) {
-      if (fs.existsSync(venvAirflow)) {
-        commandInfo = { command: venvAirflow, args: [] };
-        isLocal = true;
-        break;
-      }
-    }
-
-    if (!commandInfo) {
-      try {
-        await execPromise('uv --version');
-        await execPromise('uv run airflow version', { cwd });
-        commandInfo = { command: 'uv', args: ['run', 'airflow'] };
-      } catch { }
-    }
-
-    if (!commandInfo) {
-      try {
-        await execPromise('airflow version');
-        commandInfo = { command: 'airflow', args: [] };
-      } catch { }
-    }
-
-    const result = commandInfo ? { commandInfo, isLocal } : null;
     this.airflowCmdCache.set(cwd, result);
     return result;
+  }
+
+  private findVenvAirflow(cwd: string): { commandInfo: CommandInfo; isLocal: boolean } | null {
+    const isWindows = process.platform === 'win32';
+    const venvDirs = ['.venv', 'venv', 'env'];
+
+    for (const dir of venvDirs) {
+      const venvAirflow = path.join(
+        cwd,
+        dir,
+        isWindows ? 'Scripts' : 'bin',
+        isWindows ? 'airflow.exe' : 'airflow',
+      );
+      if (fs.existsSync(venvAirflow)) {
+        return { commandInfo: { command: venvAirflow, args: [] }, isLocal: true };
+      }
+    }
+    return null;
+  }
+
+  private async findUvAirflow(cwd: string): Promise<{ commandInfo: CommandInfo; isLocal: boolean } | null> {
+    try {
+      await execPromise('uv --version');
+      await execPromise('uv run airflow version', { cwd });
+      return { commandInfo: { command: 'uv', args: ['run', 'airflow'] }, isLocal: false };
+    } catch {
+      return null;
+    }
+  }
+
+  private async findGlobalAirflow(): Promise<{ commandInfo: CommandInfo; isLocal: boolean } | null> {
+    try {
+      await execPromise('airflow version');
+      return { commandInfo: { command: 'airflow', args: [] }, isLocal: false };
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/extension/parsers/data-processing/AirflowParser.ts
+++ b/src/extension/parsers/data-processing/AirflowParser.ts
@@ -1,21 +1,291 @@
 import { IParser } from "../IParser";
-import { PipelineData } from "../../../shared/types";
+import { PipelineData, PipelineNode, PipelineEdge } from "../../../shared/types";
+import * as fs from 'fs';
+import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execPromise = promisify(exec);
+
+interface CommandInfo {
+  command: string;
+  args: string[];
+}
 
 export class AirflowParser implements IParser {
   name = "Airflow";
+  private airflowCmdCache: Map<string, { commandInfo: CommandInfo; isLocal: boolean } | null> = new Map();
 
   canParse(fileName: string, content: string): boolean {
-    // Basic check, can be improved
-    return content.includes("from airflow import DAG");
+    const hasAirflowImport = content.includes("from airflow") || content.includes("import airflow");
+    const hasDagDefinition = content.includes("DAG(") || content.includes("@dag");
+    return hasAirflowImport && hasDagDefinition;
   }
 
   async parse(content: string, filePath: string): Promise<PipelineData> {
-    // Placeholder implementation
+    const cwd = path.dirname(filePath);
+    const airflowInfo = await this.getAirflowCmd(cwd);
+
+    if (airflowInfo) {
+      try {
+        const dagId = this.extractDagId(content);
+        if (dagId) {
+          const data = await this.parseWithCLI(dagId, filePath, airflowInfo.commandInfo, cwd);
+          // Enrich with snippets from local content
+          data.nodes = data.nodes.map(node => ({
+            ...node,
+            data: {
+              ...node.data,
+              codeDeps: [
+                ...this.extractTaskSnippet(content, node.id),
+                ...this.extractOperatorSnippet(content, node.id)
+              ].slice(0, 1) // Take the first match
+            }
+          }));
+          return data;
+        }
+      } catch (error) {
+        console.error("Airflow CLI parsing failed, falling back to regex:", error);
+      }
+    }
+
+    return this.parseWithRegex(content, filePath);
+  }
+
+  private extractDagId(content: string): string | null {
+    const dagIdMatch = content.match(/dag_id=["']([^"']+)["']/);
+    if (dagIdMatch) return dagIdMatch[1];
+
+    const decoratorMatch = content.match(/@dag\s*\([^)]*dag_id=["']([^"']+)["']/);
+    if (decoratorMatch) return decoratorMatch[1];
+
+    const positionalDagMatch = content.match(/DAG\s*\(\s*["']([^"']+)["']/);
+    if (positionalDagMatch) return positionalDagMatch[1];
+
+    return null;
+  }
+
+  private async parseWithCLI(dagId: string, filePath: string, cmdInfo: CommandInfo, cwd: string): Promise<PipelineData> {
+    const fullCmd = [cmdInfo.command, ...cmdInfo.args, 'dags', 'show', dagId].join(' ');
+    const { stdout } = await execPromise(fullCmd, { cwd });
+
+    if (!stdout || !stdout.includes('digraph')) {
+        throw new Error("Invalid DOT output from Airflow CLI");
+    }
+
+    return this.parseDot(stdout, filePath);
+  }
+
+  private parseDot(dot: string, filePath: string): PipelineData {
+    const nodes: PipelineNode[] = [];
+    const edges: PipelineEdge[] = [];
+
+    const nodeRegex = /"([^"]+)"\s+\[label="([^"]+)"/g;
+    let match;
+    while ((match = nodeRegex.exec(dot)) !== null) {
+      nodes.push({
+        id: match[1],
+        label: match[2],
+        type: 'default',
+        data: { framework: this.name }
+      });
+    }
+
+    const edgeRegex = /"([^"]+)"\s*->\s*"([^"]+)"/g;
+    while ((match = edgeRegex.exec(dot)) !== null) {
+      edges.push({
+        id: `e-${match[1]}-${match[2]}`,
+        source: match[1],
+        target: match[2]
+      });
+    }
+
     return {
       filePath,
       framework: this.name,
-      nodes: [],
-      edges: [],
+      nodes,
+      edges
     };
+  }
+
+  private parseWithRegex(content: string, filePath: string): PipelineData {
+    const nodes: PipelineNode[] = [];
+    const edges: PipelineEdge[] = [];
+
+    // Regex for TaskFlow @task
+    const taskDecoratorRegex = /@task(?:\([^)]*\))?\s+def\s+([a-zA-Z0-9_]+)/g;
+    let match;
+    while ((match = taskDecoratorRegex.exec(content)) !== null) {
+      nodes.push({
+        id: match[1],
+        label: match[1],
+        type: 'default',
+        data: {
+          framework: this.name,
+          codeDeps: this.extractTaskSnippet(content, match[1])
+        }
+      });
+    }
+
+    // Regex for classic Operators
+    const operatorRegex = /([a-zA-Z0-9_]+)\s*=\s*[a-zA-Z0-9_]*Operator\(\s*(?:task_id=["']([^"']+)["'])?/g;
+    while ((match = operatorRegex.exec(content)) !== null) {
+      const varName = match[1];
+      const taskId = match[2] || varName;
+      nodes.push({
+        id: taskId,
+        label: taskId,
+        type: 'default',
+        data: {
+          framework: this.name,
+          variableName: varName,
+          codeDeps: this.extractOperatorSnippet(content, taskId) || this.extractOperatorSnippetByVar(content, varName)
+        }
+      });
+    }
+
+    const getTaskId = (name: string) => {
+        const node = nodes.find(n => n.data?.variableName === name || n.id === name);
+        return node ? node.id : name;
+    };
+
+    const bitshiftRegexGlobal = /([a-zA-Z0-9_]+)(?:\(\))?\s*(>>|<<)\s*([a-zA-Z0-9_]+)(?:\(\))?/g;
+    let edgeMatch;
+    while ((edgeMatch = bitshiftRegexGlobal.exec(content)) !== null) {
+      const first = edgeMatch[1];
+      const op = edgeMatch[2];
+      const second = edgeMatch[3];
+
+      const source = op === '>>' ? getTaskId(first) : getTaskId(second);
+      const target = op === '>>' ? getTaskId(second) : getTaskId(first);
+
+      edges.push({
+        id: `e-${source}-${target}`,
+        source,
+        target
+      });
+    }
+
+    const methodRegex = /([a-zA-Z0-9_]+)\.(set_downstream|set_upstream)\s*\(\s*([a-zA-Z0-9_]+)\s*\)/g;
+    while ((edgeMatch = methodRegex.exec(content)) !== null) {
+        const first = edgeMatch[1];
+        const method = edgeMatch[2];
+        const second = edgeMatch[3];
+
+        const source = method === 'set_downstream' ? getTaskId(first) : getTaskId(second);
+        const target = method === 'set_downstream' ? getTaskId(second) : getTaskId(first);
+
+        edges.push({
+            id: `e-${source}-${target}`,
+            source,
+            target
+        });
+    }
+
+    return {
+      filePath,
+      framework: this.name,
+      nodes,
+      edges
+    };
+  }
+
+  private extractTaskSnippet(content: string, taskId: string): any[] {
+    const lines = content.split('\n');
+    const startIdx = lines.findIndex((line, idx) =>
+        line.includes(`@task`) &&
+        (lines[idx + 1]?.includes(`def ${taskId}`) || lines[idx + 2]?.includes(`def ${taskId}`))
+    );
+    if (startIdx === -1) return [];
+
+    let endIdx = startIdx + 1;
+    for (let i = startIdx + 1; i < lines.length; i++) {
+        if (lines[i].includes(`def ${taskId}`)) {
+            const startIndent = lines[i].search(/\S/);
+            for (let j = i + 1; j < lines.length; j++) {
+                if (lines[j].trim() !== '' && !lines[j].trim().startsWith('#')) {
+                    const currentIndent = lines[j].search(/\S/);
+                    if (currentIndent <= startIndent && currentIndent !== -1) {
+                        endIdx = j - 1;
+                        break;
+                    }
+                }
+                endIdx = j;
+            }
+            break;
+        }
+    }
+
+    return [{
+      path: 'dag.py',
+      snippet: lines.slice(startIdx, endIdx + 1).join('\n')
+    }];
+  }
+
+  private extractOperatorSnippet(content: string, taskId: string): any[] {
+    const lines = content.split('\n');
+    const lineIdx = lines.findIndex(line => line.includes(`task_id=["']${taskId}["']`) || line.includes(`task_id = ["']${taskId}["']`));
+    if (lineIdx === -1) return [];
+
+    return [{
+      path: 'dag.py',
+      snippet: lines[lineIdx].trim()
+    }];
+  }
+
+  private extractOperatorSnippetByVar(content: string, varName: string): any[] {
+    const lines = content.split('\n');
+    const lineIdx = lines.findIndex(line => line.includes(`${varName} =`) && line.includes('Operator'));
+    if (lineIdx === -1) return [];
+
+    return [{
+      path: 'dag.py',
+      snippet: lines[lineIdx].trim()
+    }];
+  }
+
+  private async getAirflowCmd(cwd: string): Promise<{ commandInfo: CommandInfo; isLocal: boolean } | null> {
+    if (this.airflowCmdCache.has(cwd)) {
+      return this.airflowCmdCache.get(cwd)!;
+    }
+
+    const isWindows = process.platform === 'win32';
+    const venvDirs = ['.venv', 'venv', 'env'];
+    const venvPaths: string[] = [];
+    for (const dir of venvDirs) {
+      venvPaths.push(
+        path.join(cwd, dir, isWindows ? 'Scripts' : 'bin', isWindows ? 'airflow.exe' : 'airflow')
+      );
+    }
+
+    let commandInfo: CommandInfo | null = null;
+    let isLocal = false;
+
+    for (const venvAirflow of venvPaths) {
+      if (fs.existsSync(venvAirflow)) {
+        commandInfo = { command: venvAirflow, args: [] };
+        isLocal = true;
+        break;
+      }
+    }
+
+    if (!commandInfo) {
+      try {
+        await execPromise('uv --version');
+        await execPromise('uv run airflow version', { cwd });
+        commandInfo = { command: 'uv', args: ['run', 'airflow'] };
+      } catch { }
+    }
+
+    if (!commandInfo) {
+      try {
+        await execPromise('airflow version');
+        commandInfo = { command: 'airflow', args: [] };
+      } catch { }
+    }
+
+    const result = commandInfo ? { commandInfo, isLocal } : null;
+    this.airflowCmdCache.set(cwd, result);
+    return result;
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,11 +1,24 @@
 import { PipelinePatternType, AnnotationColorScheme } from './base-types';
 
+export interface CodeSnippet {
+  path: string;
+  snippet: string;
+}
+
 export interface PipelineNode {
   id: string;
   label: string;
   type?: string;
   status?: 'idle' | 'running' | 'success' | 'failed';
-  data?: any;
+  data?: {
+    framework?: string;
+    codeDeps?: CodeSnippet[];
+    params?: any;
+    variableName?: string;
+    dataType?: string;
+    contents?: string[];
+    [key: string]: any;
+  };
 }
 
 export interface PipelineEdge {

--- a/tests/AirflowParser.test.ts
+++ b/tests/AirflowParser.test.ts
@@ -1,0 +1,101 @@
+import { AirflowParser } from '../src/extension/parsers/data-processing/AirflowParser';
+
+describe('AirflowParser', () => {
+  const parser = new AirflowParser();
+
+  describe('canParse', () => {
+    it('should return true for classic DAG definition', () => {
+      const content = `
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+with DAG("test_dag", start_date=datetime(2021, 1, 1)) as dag:
+    task = BashOperator(task_id="test", bash_command="echo hello")
+`;
+      expect(parser.canParse('dag.py', content)).toBe(true);
+    });
+
+    it('should return true for TaskFlow API DAG definition', () => {
+      const content = `
+from airflow.decorators import dag, task
+
+@dag(dag_id="test_dag")
+def my_dag():
+    @task
+    def my_task():
+        return "hello"
+    my_task()
+`;
+      expect(parser.canParse('dag.py', content)).toBe(true);
+    });
+
+    it('should return false for non-Airflow file', () => {
+      const content = `
+import pandas as pd
+df = pd.read_csv("data.csv")
+`;
+      expect(parser.canParse('script.py', content)).toBe(false);
+    });
+  });
+
+  describe('parseWithRegex', () => {
+    it('should extract tasks and edges from TaskFlow DAG', () => {
+      const content = `
+@dag(dag_id="test_dag")
+def my_dag():
+    @task
+    def task_a():
+        return "a"
+
+    @task
+    def task_b():
+        return "b"
+
+    task_a() >> task_b()
+`;
+      const result = (parser as any).parseWithRegex(content, 'dag.py');
+      expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'task_a' }));
+      expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'task_b' }));
+      expect(result.edges).toContainEqual(expect.objectContaining({ source: 'task_a', target: 'task_b' }));
+    });
+
+    it('should extract tasks from classic Operators', () => {
+        const content = `
+task1 = BashOperator(task_id="bash_task", bash_command="echo 1")
+task2 = PythonOperator(task_id="python_task", python_callable=my_func)
+task1 >> task2
+`;
+        const result = (parser as any).parseWithRegex(content, 'dag.py');
+        expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'bash_task' }));
+        expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'python_task' }));
+        expect(result.edges).toContainEqual(expect.objectContaining({ source: 'bash_task', target: 'python_task' }));
+    });
+
+    it('should extract edges from set_downstream', () => {
+        const content = `
+task1 = BashOperator(task_id="t1")
+task2 = BashOperator(task_id="t2")
+task1.set_downstream(task2)
+`;
+        const result = (parser as any).parseWithRegex(content, 'dag.py');
+        expect(result.edges).toContainEqual(expect.objectContaining({ source: 't1', target: 't2' }));
+    });
+  });
+
+  describe('parseDot', () => {
+    it('should parse Airflow DOT output', () => {
+      const dot = `
+digraph test_dag {
+	"task_1" [label="task_1" shape=rect]
+	"task_2" [label="task_2" shape=rect]
+	"task_1" -> "task_2"
+}
+      `;
+      const result = (parser as any).parseDot(dot, 'dag.py');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.nodes[0]).toEqual(expect.objectContaining({ id: 'task_1', label: 'task_1' }));
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]).toEqual(expect.objectContaining({ source: 'task_1', target: 'task_2' }));
+    });
+  });
+});

--- a/tests/AirflowParser.test.ts
+++ b/tests/AirflowParser.test.ts
@@ -105,8 +105,26 @@ def my_dag():
 
       expect(tryParseWithCLISpy).toHaveBeenCalledTimes(1);
       expect(parseWithRegexSpy).toHaveBeenCalledTimes(1);
+      expect(parseWithRegexSpy).toHaveBeenCalledWith(dagContent, filePath);
       expect(result).toBe(regexResult);
     });
+
+    it('should fall back directly to regex when Airflow CLI is not available', async () => {
+        const regexResult = { nodes: [{ id: 'task_from_regex', label: 'task_from_regex' }], edges: [] };
+
+        jest.spyOn(parser as any, 'getAirflowCmd').mockResolvedValue(null);
+
+        const tryParseWithCLISpy = jest.spyOn(parser as any, 'tryParseWithCLI');
+        const parseWithRegexSpy = jest
+          .spyOn(parser as any, 'parseWithRegex')
+          .mockResolvedValue(regexResult);
+
+        const result = await parser.parse(dagContent, filePath);
+
+        expect(tryParseWithCLISpy).not.toHaveBeenCalled();
+        expect(parseWithRegexSpy).toHaveBeenCalledTimes(1);
+        expect(result).toBe(regexResult);
+      });
 
     it('should skip CLI and use regex when no dag_id is extracted', async () => {
       const regexResult = { nodes: [{ id: 'task_from_regex', label: 'task_from_regex' }], edges: [] };
@@ -150,7 +168,10 @@ def my_dag():
 
       const nodeA = result.nodes.find((n: any) => n.id === 'task_a');
       expect(nodeA.data.codeDeps.length).toBeGreaterThan(0);
-      expect(nodeA.data.codeDeps[0].snippet).toContain('def task_a');
+      expect(nodeA.data.codeDeps[0]).toEqual(expect.objectContaining({
+          path: 'dag.py',
+          snippet: expect.stringContaining('def task_a')
+      }));
     });
 
     it('should handle << and set_upstream', () => {
@@ -186,6 +207,20 @@ bash_task_var >> python_task_var
         expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'python_task' }));
         expect(result.edges).toContainEqual(expect.objectContaining({ source: 'bash_task', target: 'python_task' }));
     });
+
+    it('should extract snippets for classic operators', () => {
+        const content = `
+bash_task = BashOperator(task_id="bash_task", bash_command="echo 1")
+`;
+        const result = (parser as any).parseWithRegex(content, 'dag.py');
+        const bashNode = result.nodes.find((n: any) => n.id === 'bash_task');
+        expect(bashNode).toBeDefined();
+        expect(bashNode.data.codeDeps.length).toBeGreaterThan(0);
+        expect(bashNode.data.codeDeps[0]).toEqual(expect.objectContaining({
+            path: 'dag.py',
+            snippet: expect.stringContaining('BashOperator(task_id="bash_task"')
+        }));
+    });
   });
 
   describe('parseDot', () => {
@@ -206,12 +241,38 @@ digraph test_dag {
   });
 
   describe('tryParseWithCLI', () => {
-      it('should return null when CLI output is not DOT', async () => {
+      it('should return null when CLI output is not DOT (missing digraph)', async () => {
           jest.spyOn(parser as any, 'extractDagId').mockReturnValue('test_dag');
-          jest.spyOn(parser as any, 'parseWithCLI').mockRejectedValue(new Error('Invalid DOT'));
+          jest.spyOn(parser as any, 'parseWithCLI').mockRejectedValue(new Error('Invalid DOT output from Airflow CLI'));
 
           const result = await (parser as any).tryParseWithCLI('content', 'dag.py', { command: 'airflow', args: [] }, '.');
           expect(result).toBeNull();
       });
+  });
+
+  describe('extractTaskSnippet', () => {
+    it('extracts multi-line TaskFlow function bodies with path and snippet', () => {
+      const content = `
+from airflow.decorators import task
+
+@task
+def task_a():
+    x = 1
+    y = 2
+    return x + y
+`;
+      const parserAny = parser as any;
+      const snippets = parserAny.extractTaskSnippet(content, 'dag.py', 'task_a');
+
+      expect(snippets).toHaveLength(1);
+      expect(snippets[0]).toEqual(
+        expect.objectContaining({
+          path: 'dag.py',
+          snippet: expect.stringContaining('def task_a'),
+        }),
+      );
+      expect(snippets[0].snippet).toContain('x = 1');
+      expect(snippets[0].snippet).toContain('return x + y');
+    });
   });
 });

--- a/tests/AirflowParser.test.ts
+++ b/tests/AirflowParser.test.ts
@@ -1,7 +1,11 @@
 import { AirflowParser } from '../src/extension/parsers/data-processing/AirflowParser';
 
 describe('AirflowParser', () => {
-  const parser = new AirflowParser();
+  let parser: AirflowParser;
+
+  beforeEach(() => {
+    parser = new AirflowParser();
+  });
 
   describe('canParse', () => {
     it('should return true for classic DAG definition', () => {
@@ -38,6 +42,92 @@ df = pd.read_csv("data.csv")
     });
   });
 
+  describe('parse', () => {
+    const filePath = 'dags/test_dag.py';
+    const dagContent = `
+from airflow.decorators import dag, task
+
+@dag(dag_id="test_dag")
+def my_dag():
+    @task
+    def my_task():
+        return "hello"
+    my_task()
+`;
+
+    const nonDagContent = `
+def my_dag():
+    return "not an airflow dag"
+`;
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should use Airflow CLI when available and successful', async () => {
+      const cliResult = { nodes: [{ id: 'task1', label: 'task1' }], edges: [] };
+
+      jest.spyOn(parser as any, 'getAirflowCmd').mockResolvedValue({
+          commandInfo: { command: 'airflow', args: [] },
+          isLocal: false
+      });
+
+      const tryParseWithCLISpy = jest
+        .spyOn(parser as any, 'tryParseWithCLI')
+        .mockResolvedValue(cliResult);
+
+      const parseWithRegexSpy = jest.spyOn(parser as any, 'parseWithRegex');
+
+      const result = await parser.parse(dagContent, filePath);
+
+      expect(tryParseWithCLISpy).toHaveBeenCalledTimes(1);
+      expect(parseWithRegexSpy).not.toHaveBeenCalled();
+      expect(result).toBe(cliResult);
+    });
+
+    it('should fall back to regex when tryParseWithCLI returns null', async () => {
+      const regexResult = { nodes: [{ id: 'task_from_regex', label: 'task_from_regex' }], edges: [] };
+
+      jest.spyOn(parser as any, 'getAirflowCmd').mockResolvedValue({
+        commandInfo: { command: 'airflow', args: [] },
+        isLocal: false
+      });
+
+      const tryParseWithCLISpy = jest
+        .spyOn(parser as any, 'tryParseWithCLI')
+        .mockResolvedValue(null);
+
+      const parseWithRegexSpy = jest
+        .spyOn(parser as any, 'parseWithRegex')
+        .mockResolvedValue(regexResult);
+
+      const result = await parser.parse(dagContent, filePath);
+
+      expect(tryParseWithCLISpy).toHaveBeenCalledTimes(1);
+      expect(parseWithRegexSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBe(regexResult);
+    });
+
+    it('should skip CLI and use regex when no dag_id is extracted', async () => {
+      const regexResult = { nodes: [{ id: 'task_from_regex', label: 'task_from_regex' }], edges: [] };
+
+      jest.spyOn(parser as any, 'getAirflowCmd').mockResolvedValue({
+        commandInfo: { command: 'airflow', args: [] },
+        isLocal: false
+      });
+
+      const tryParseWithCLISpy = jest.spyOn(parser as any, 'tryParseWithCLI');
+      const parseWithRegexSpy = jest
+        .spyOn(parser as any, 'parseWithRegex')
+        .mockResolvedValue(regexResult);
+
+      const result = await parser.parse(nonDagContent, filePath);
+
+      expect(parseWithRegexSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBe(regexResult);
+    });
+  });
+
   describe('parseWithRegex', () => {
     it('should extract tasks and edges from TaskFlow DAG', () => {
       const content = `
@@ -57,28 +147,44 @@ def my_dag():
       expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'task_a' }));
       expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'task_b' }));
       expect(result.edges).toContainEqual(expect.objectContaining({ source: 'task_a', target: 'task_b' }));
+
+      const nodeA = result.nodes.find((n: any) => n.id === 'task_a');
+      expect(nodeA.data.codeDeps.length).toBeGreaterThan(0);
+      expect(nodeA.data.codeDeps[0].snippet).toContain('def task_a');
     });
 
-    it('should extract tasks from classic Operators', () => {
+    it('should handle << and set_upstream', () => {
         const content = `
-task1 = BashOperator(task_id="bash_task", bash_command="echo 1")
-task2 = PythonOperator(task_id="python_task", python_callable=my_func)
+task_b() << task_a()
+task_d.set_upstream(task_c)
+`;
+        const result = (parser as any).parseWithRegex(content, 'dag.py');
+        expect(result.edges).toContainEqual(expect.objectContaining({ source: 'task_a', target: 'task_b' }));
+        expect(result.edges).toContainEqual(expect.objectContaining({ source: 'task_c', target: 'task_d' }));
+    });
+
+    it('should infer task ids from variable names when task_id is omitted', () => {
+        const content = `
+task1 = BashOperator()
+task2 = BashOperator()
 task1 >> task2
+`;
+        const result = (parser as any).parseWithRegex(content, 'dag.py');
+        expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'task1' }));
+        expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'task2' }));
+        expect(result.edges).toContainEqual(expect.objectContaining({ source: 'task1', target: 'task2' }));
+    });
+
+    it('should resolve dependencies using both variable names and task_ids', () => {
+        const content = `
+bash_task_var = BashOperator(task_id="bash_task")
+python_task_var = PythonOperator(task_id="python_task")
+bash_task_var >> python_task_var
 `;
         const result = (parser as any).parseWithRegex(content, 'dag.py');
         expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'bash_task' }));
         expect(result.nodes).toContainEqual(expect.objectContaining({ id: 'python_task' }));
         expect(result.edges).toContainEqual(expect.objectContaining({ source: 'bash_task', target: 'python_task' }));
-    });
-
-    it('should extract edges from set_downstream', () => {
-        const content = `
-task1 = BashOperator(task_id="t1")
-task2 = BashOperator(task_id="t2")
-task1.set_downstream(task2)
-`;
-        const result = (parser as any).parseWithRegex(content, 'dag.py');
-        expect(result.edges).toContainEqual(expect.objectContaining({ source: 't1', target: 't2' }));
     });
   });
 
@@ -97,5 +203,15 @@ digraph test_dag {
       expect(result.edges).toHaveLength(1);
       expect(result.edges[0]).toEqual(expect.objectContaining({ source: 'task_1', target: 'task_2' }));
     });
+  });
+
+  describe('tryParseWithCLI', () => {
+      it('should return null when CLI output is not DOT', async () => {
+          jest.spyOn(parser as any, 'extractDagId').mockReturnValue('test_dag');
+          jest.spyOn(parser as any, 'parseWithCLI').mockRejectedValue(new Error('Invalid DOT'));
+
+          const result = await (parser as any).tryParseWithCLI('content', 'dag.py', { command: 'airflow', args: [] }, '.');
+          expect(result).toBeNull();
+      });
   });
 });


### PR DESCRIPTION
This PR introduces support for Apache Airflow version 2.x and 3.x. 

Key features:
1. **Modern Detection**: The parser now recognizes `@dag` and `@task` decorators from the TaskFlow API in addition to classic `DAG()` constructor calls.
2. **CLI Integration**: If an Airflow environment is detected (venv, uv, or global), the extension uses `airflow dags show` to retrieve the exact DAG structure in DOT format, ensuring high-fidelity visualization.
3. **Static Fallback**: A sophisticated regex-based fallback ensures that pipelines are still visualized even if the CLI is not configured or fails. It supports bitshift operators (`>>`, `<<`) and method-based dependency definitions (`set_downstream`, `set_upstream`).
4. **Code Snippets**: Users can now view task source code directly in the visualization for both TaskFlow functions and classic Operator assignments.
5. **Testing**: Comprehensive tests cover detection, regex parsing, and DOT parsing.

---
*PR created automatically by Jules for task [15059195706509956576](https://jules.google.com/task/15059195706509956576) started by @Resmung0*

## Summary by Sourcery

Add robust Airflow DAG parser that supports modern TaskFlow and classic DAG definitions, including optional CLI-assisted graph extraction and a regex-based fallback.

New Features:
- Support parsing Airflow DAGs defined via TaskFlow decorators and classic DAG constructors.
- Integrate with local, uv-based, or global Airflow CLI to retrieve DAG structure in DOT format when available.
- Extract and attach task code snippets for both TaskFlow tasks and classic Operator tasks to pipeline nodes.

Enhancements:
- Implement regex-based parsing of Airflow tasks and dependencies, including bitshift operators and set_upstream/set_downstream methods, as a fallback when the CLI is unavailable or fails.

Tests:
- Add unit tests covering canParse detection, regex-based DAG parsing, and DOT graph parsing from Airflow CLI output.